### PR TITLE
Only show RA candidates with verified Loa 3 second factors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "jms/di-extra-bundle": "~1.4.0",
         "surfnet/stepup-middleware-client-bundle": "^1.3",
         "surfnet/stepup-saml-bundle": "^2.5",
-        "surfnet/stepup-bundle": "^1.5",
+        "surfnet/stepup-bundle": "^1.6",
         "surfnet/stepup-u2f-bundle": "dev-develop",
         "guzzlehttp/guzzle": "~4",
         "symfony/swiftmailer-bundle": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "fortawesome/font-awesome": "~4.2.0",
         "jms/translation-bundle": "~1.1.0",
         "jms/di-extra-bundle": "~1.4.0",
-        "surfnet/stepup-middleware-client-bundle": "^1.3",
+        "surfnet/stepup-middleware-client-bundle": "^1.6",
         "surfnet/stepup-saml-bundle": "^2.5",
         "surfnet/stepup-bundle": "^1.6",
         "surfnet/stepup-u2f-bundle": "dev-develop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a41ba886eea7bdd7ae354d235d770c9d",
-    "content-hash": "35c961e230f4e3952ed11a2f0361fac2",
+    "hash": "784511afeb0af2dfbfbb9d708790d7b8",
+    "content-hash": "501b219a7aec786155211d9641188de7",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1983,16 +1983,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/SURFnet/Stepup-bundle.git",
-                "reference": "4ad7ebe9f9075ec39c5d1fc8449fe8fef33e60d2"
+                "url": "https://github.com/OpenConext/Stepup-bundle.git",
+                "reference": "aff0a98d38b6dfb3a501877329e36538a7abc2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-bundle/zipball/4ad7ebe9f9075ec39c5d1fc8449fe8fef33e60d2",
-                "reference": "4ad7ebe9f9075ec39c5d1fc8449fe8fef33e60d2",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/aff0a98d38b6dfb3a501877329e36538a7abc2b7",
+                "reference": "aff0a98d38b6dfb3a501877329e36538a7abc2b7",
                 "shasum": ""
             },
             "require": {
@@ -2032,19 +2032,19 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2016-08-03 07:45:32"
+            "time": "2017-02-08 16:36:17"
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
             "version": "1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/SURFnet/Stepup-Middleware-clientbundle.git",
+                "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
                 "reference": "ee1dbf1664ca959500609793ec8c185a367cb9ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-Middleware-clientbundle/zipball/ee1dbf1664ca959500609793ec8c185a367cb9ca",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/ee1dbf1664ca959500609793ec8c185a367cb9ca",
                 "reference": "ee1dbf1664ca959500609793ec8c185a367cb9ca",
                 "shasum": ""
             },
@@ -2088,12 +2088,12 @@
             "version": "2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/SURFnet/Stepup-saml-bundle.git",
+                "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
                 "reference": "3ee050d16f76bf63b48fa01af3e75e1b42668d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/3ee050d16f76bf63b48fa01af3e75e1b42668d72",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/3ee050d16f76bf63b48fa01af3e75e1b42668d72",
                 "reference": "3ee050d16f76bf63b48fa01af3e75e1b42668d72",
                 "shasum": ""
             },
@@ -2136,12 +2136,12 @@
             "version": "dev-develop",
             "source": {
                 "type": "git",
-                "url": "https://github.com/SURFnet/Stepup-u2f-bundle.git",
+                "url": "https://github.com/OpenConext/Stepup-u2f-bundle.git",
                 "reference": "b28737d7b8df5ecbdf7a1e952ecfb530a2951c05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-u2f-bundle/zipball/b28737d7b8df5ecbdf7a1e952ecfb530a2951c05",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-u2f-bundle/zipball/b28737d7b8df5ecbdf7a1e952ecfb530a2951c05",
                 "reference": "b28737d7b8df5ecbdf7a1e952ecfb530a2951c05",
                 "shasum": ""
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "784511afeb0af2dfbfbb9d708790d7b8",
-    "content-hash": "501b219a7aec786155211d9641188de7",
+    "hash": "477b9859c8759434ab1e240174534b13",
+    "content-hash": "5a0f28db71e027c87c10417ebe4b6204",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2036,16 +2036,16 @@
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
-            "version": "1.3.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "ee1dbf1664ca959500609793ec8c185a367cb9ca"
+                "reference": "d44e25297dca977be2f5c5f2a0493845d538eaca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/ee1dbf1664ca959500609793ec8c185a367cb9ca",
-                "reference": "ee1dbf1664ca959500609793ec8c185a367cb9ca",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/d44e25297dca977be2f5c5f2a0493845d538eaca",
+                "reference": "d44e25297dca977be2f5c5f2a0493845d538eaca",
                 "shasum": ""
             },
             "require": {
@@ -2081,7 +2081,7 @@
                 "Apache-2.0"
             ],
             "description": "Symfony2 bundle for consuming the Step-up Middleware API.",
-            "time": "2016-08-03 08:56:12"
+            "time": "2017-02-22 15:55:52"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Service;
 
 use Psr\Log\LoggerInterface;
+use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\RaCandidateSearchQuery;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Command\AccreditIdentityCommand;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaCandidateService as ApiRaCandidateService;
@@ -77,6 +79,8 @@ class RaCandidateService
             $query->setOrderDirection($command->orderDirection);
         }
 
+        $query->setSecondFactorTypes($this->getLoa3SecondFactorTypes());
+
         return $this->apiRaCandidateService->search($query);
     }
 
@@ -117,5 +121,22 @@ class RaCandidateService
         }
 
         return $result->isSuccessful();
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getLoa3SecondFactorTypes()
+    {
+        $loa3 = new Loa(Loa::LOA_3, 'LOA3');
+
+        return array_filter(
+            SecondFactorType::getAvailableSecondFactorTypes(),
+            function ($secondFactorType) use ($loa3) {
+                $secondFactorType = new SecondFactorType($secondFactorType);
+
+                return $secondFactorType->canSatisfy($loa3);
+            }
+        );
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php
@@ -28,23 +28,20 @@ use Surfnet\StepupRa\RaBundle\Command\AccreditCandidateCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaCandidatesCommand;
 use Surfnet\StepupRa\RaBundle\Exception\InvalidArgumentException;
 
-/**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */
 class RaCandidateService
 {
     /**
-     * @var ApiRaCandidateService
+     * @var \Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaCandidateService
      */
     private $apiRaCandidateService;
 
     /**
-     * @var CommandService
+     * @var \Surfnet\StepupRa\RaBundle\Service\CommandService
      */
     private $commandService;
 
     /**
-     * @var LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     private $logger;
 

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaCandidateService.php
@@ -28,6 +28,9 @@ use Surfnet\StepupRa\RaBundle\Command\AccreditCandidateCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaCandidatesCommand;
 use Surfnet\StepupRa\RaBundle\Exception\InvalidArgumentException;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class RaCandidateService
 {
     /**


### PR DESCRIPTION
This prevents assigning RA(A) rights to users who don't have the correct LoA3 second factor.

Depends on https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/50

https://www.pivotaltracker.com/story/show/131617617