### PR TITLE
Show expiration error early in the vetting process

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -37,6 +37,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  */
 class VettingController extends Controller
 {
@@ -107,6 +108,27 @@ class VettingController extends Controller
         $command->authorityId = $this->getIdentity()->id;
         $command->authorityLoa = $token->getLoa();
         $command->secondFactor = $secondFactor;
+
+        if ($this->getVettingService()->isExpiredRegistrationCode($command)) {
+            $form->addError(
+                new FormError(
+                    $this->getTranslator()
+                        ->trans(
+                            'ra.verify_identity.registration_code_expired',
+                            [
+                                '%self_service_url%' => $this->getParameter('surfnet_stepup_ra.self_service_url'),
+                            ]
+                        )
+                )
+            );
+
+            $logger->notice(
+                'Second factor registration code is expired',
+                ['registration_requested_at' => $secondFactor->registrationRequestedAt->format('Y-m-d')]
+            );
+
+            return ['form' => $form->createView()];
+        }
 
         if (!$this->getVettingService()->isLoaSufficientToStartProcedure($command)) {
             $form->addError(new FormError('ra.form.start_vetting_procedure.loa_insufficient'));

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Service/VettingServiceTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Service/VettingServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Service;
+
+use Mockery;
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VerifiedSecondFactor;
+use Surfnet\StepupRa\RaBundle\Command\StartVettingProcedureCommand;
+use Surfnet\StepupRa\RaBundle\Service\VettingService;
+
+final class VettingServiceTest extends TestCase
+{
+    /**
+     * @test
+     * @group vetting
+     * @dataProvider validRegistrationDatesProvider
+     */
+    public function registration_code_is_valid_within_two_weeks_after_verification($registrationRequestedAt)
+    {
+        $command = new StartVettingProcedureCommand();
+        $command->secondFactor = new VerifiedSecondFactor();
+        $command->secondFactor->registrationRequestedAt = $registrationRequestedAt;
+
+        $service = Mockery::mock(VettingService::class)->makePartial();
+
+        $this->assertFalse(
+            $service->isExpiredRegistrationCode($command)
+        );
+    }
+
+    public function validRegistrationDatesProvider() {
+        return [
+            [date_create('- 1 week')],
+            [date_create('- 2 weeks')],
+            [date_create('- 2 weeks')->setTime(0, 0, 0)],
+            [date_create('- 2 weeks')->setTime(23, 59, 59)],
+        ];
+    }
+
+    /**
+     * @test
+     * @group vetting
+     * @dataProvider expiredRegistrationDatesProvider
+     */
+    public function registration_code_is_invalid_two_weeks_after_verification($registrationRequestedAt)
+    {
+        $command = new StartVettingProcedureCommand();
+        $command->secondFactor = new VerifiedSecondFactor();
+        $command->secondFactor->registrationRequestedAt = $registrationRequestedAt;
+
+        $service = Mockery::mock(VettingService::class)->makePartial();
+
+        $this->assertTrue(
+            $service->isExpiredRegistrationCode($command)
+        );
+    }
+
+    public function expiredRegistrationDatesProvider() {
+        return [
+            [date_create('- 3 weeks')],
+            [date_create('- 15 days')->setTime(0, 0, 0)],
+            [date_create('- 15 days')->setTime(23, 59, 59)],
+        ];
+    }
+}


### PR DESCRIPTION
Instead of showing the expiration error when the vetting process is
almost completed, show it right after looking up the registration
code. This saves time of the user and the RA.

See: https://www.pivotaltracker.com/story/show/133928873