### PR TITLE
Implement is gssf deprecation

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupRa\RaBundle\Command\StartVettingProcedureCommand;
 use Surfnet\StepupRa\RaBundle\Command\VerifyIdentityCommand;
@@ -149,7 +150,7 @@ class VettingController extends Controller
             return $this->redirectToRoute('ra_vetting_yubikey_verify', ['procedureId' => $procedureId]);
         } elseif ($secondFactorType->isSms()) {
             return $this->redirectToRoute('ra_vetting_sms_send_challenge', ['procedureId' => $procedureId]);
-        } elseif ($secondFactorType->isGssf()) {
+        } elseif ($this->getSecondFactorTypeService()->isGssf($secondFactorType)) {
             return $this->redirectToRoute(
                 'ra_vetting_gssf_initiate',
                 [
@@ -286,6 +287,14 @@ class VettingController extends Controller
     private function getSecondFactorService()
     {
         return $this->get('ra.service.second_factor');
+    }
+
+    /**
+     * @return SecondFactorTypeService
+     */
+    private function getSecondFactorTypeService()
+    {
+        return $this->get('surfnet_stepup.service.second_factor_type');
     }
 
     /**


### PR DESCRIPTION
This PR makes sure the isGssf method is no longer called on the SeconfFacorType class but on the SFTypeService instead.

This required the installation of version 3.0.0 of the stepup bundle.

See [pivotal](https://www.pivotaltracker.com/story/show/153250034) tracker for more information