### PR TITLE
Ignore unknown attributes in attribute dictionary

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -100,6 +100,8 @@ surfnet_stepup_middleware_client:
 
 surfnet_saml:
     hosted:
+        attribute_dictionary:
+            ignore_unknown_attributes: true
         service_provider:
             enabled: true
             assertion_consumer_route: ra_serviceprovider_consume_assertion


### PR DESCRIPTION
Prevents UnknownUrnExceptions when IDP sends an attribute not defined
in the stepup-saml-bundle. Gateway already does this:

    https://github.com/OpenConext/Stepup-Gateway/pull/147/files