### PR TITLE
Translate Yubikey OTP error messages

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
@@ -61,9 +61,9 @@ class YubikeyController extends SecondFactorController
             }
 
             if ($result->wasOtpInvalid()) {
-                $form->get('otp')->addError(new FormError('ra.verify_yubikey_command.otp.otp_invalid'));
+                $form->addError(new FormError('ra.verify_yubikey_command.otp.otp_invalid'));
             } elseif ($result->didOtpVerificationFail()) {
-                $form->get('otp')->addError(new FormError('ra.verify_yubikey_command.otp.verification_error'));
+                $form->addError(new FormError('ra.verify_yubikey_command.otp.verification_error'));
             } else {
                 $form->addError(new FormError('ra.prove_yubikey_possession.different_yubikey_used'));
             }


### PR DESCRIPTION
Error messages on a form element are not translated by default, error
messages on the form itself are. To fix the described issue, we add
error messages on the parent form just like all other errors in RA.

![screenshot_20180702_100801](https://user-images.githubusercontent.com/448056/42152388-4378e048-7de0-11e8-8349-e09ecedeaf87.png)

See https://www.pivotaltracker.com/story/show/158660535