### PR TITLE
Set Symfony environment from cookie if available

### DIFF
--- a/app_dev.php.dist
+++ b/app_dev.php.dist
@@ -8,7 +8,12 @@ Debug::enable(~E_USER_DEPRECATED);
 
 require_once __DIR__.'/../app/AppKernel.php';
 
-$kernel = new AppKernel('dev', true);
+$env = 'dev';
+if (isset($_SERVER['APP_DEV'])) {
+    $env = $_SERVER['APP_DEV'];
+}
+
+$kernel = new AppKernel($env, true);
 $kernel->loadClassCache();
 
 $request = Request::createFromGlobals();


### PR DESCRIPTION
When the 'testcookie' is set, Nginx and PHP-fpm will set the APP_DEV
environment variable to 'test'.

If the variable for some reason is not set, the system falls back on the
default 'dev' environment.

See: https://www.pivotaltracker.com/story/show/156570267