### PR TITLE
Symfony 3.4 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ php:
   - 5.6
   - 7.0
 
+matrix:
+  allow_failures:
+  - php: 7.0
+
 env:
   global:
     - SYMFONY_ENV=test
@@ -26,7 +30,6 @@ before_script:
 
 script:
   - ant
-
 
 branches:
   only:

--- a/app/AppCache.php
+++ b/app/AppCache.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
+
+class AppCache extends HttpCache
+{
+}

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -39,8 +39,6 @@ class AppKernel extends Kernel
             new Surfnet\SamlBundle\SurfnetSamlBundle(),
             new Surfnet\StepupBundle\SurfnetStepupBundle(),
             new JMS\TranslationBundle\JMSTranslationBundle(),
-            new JMS\DiExtraBundle\JMSDiExtraBundle($this),
-            new JMS\AopBundle\JMSAopBundle(),
             // Replace with Pagerfanta https://www.pivotaltracker.com/story/show/89688680
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
             new Surfnet\StepupU2fBundle\SurfnetStepupU2fBundle(),
@@ -50,7 +48,6 @@ class AppKernel extends Kernel
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-            $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
         }
 
         return $bundles;

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -18,10 +18,9 @@ framework:
     templating:
         engines: ['twig', 'php']
     assets:
-        version: %asset_version%
+        version: "%asset_version%"
     default_locale:  "%default_locale%"
     trusted_hosts:   ~
-    trusted_proxies: %trusted_proxies%
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~
@@ -74,9 +73,9 @@ services:
         tags: [{ name: twig.extension }]
 
 surfnet_stepup_ra_ra:
-    required_loa: %loa_required_for_login%
-    enabled_second_factors: %enabled_second_factors%
-    enabled_generic_second_factors: %enabled_generic_second_factors%
+    required_loa: "%loa_required_for_login%"
+    enabled_second_factors: "%enabled_second_factors%"
+    enabled_generic_second_factors: "%enabled_generic_second_factors%"
     session_lifetimes:
         max_absolute_lifetime: "%session_max_absolute_lifetime%"
         max_relative_lifetime: "%session_max_relative_lifetime%"
@@ -92,11 +91,11 @@ mopa_bootstrap:
 
 surfnet_stepup_middleware_client:
     authorisation:
-        username: %middleware_credentials_username%
-        password: %middleware_credentials_password%
+        username: "%middleware_credentials_username%"
+        password: "%middleware_credentials_password%"
     url:
-        command_api: %middleware_url_command_api%
-        api: %middleware_url_api%
+        command_api: "%middleware_url_command_api%"
+        api: "%middleware_url_api%"
 
 surfnet_saml:
     hosted:
@@ -105,48 +104,48 @@ surfnet_saml:
         service_provider:
             enabled: true
             assertion_consumer_route: ra_serviceprovider_consume_assertion
-            public_key: %saml_sp_publickey%
-            private_key: %saml_sp_privatekey%
+            public_key: "%saml_sp_publickey%"
+            private_key: "%saml_sp_privatekey%"
         metadata:
             entity_id_route: ra_saml_metadata
-            public_key: %saml_metadata_publickey%
-            private_key: %saml_metadata_privatekey%
+            public_key: "%saml_metadata_publickey%"
+            private_key: "%saml_metadata_privatekey%"
     remote:
         identity_provider:
             enabled: true
-            entity_id: %saml_remote_idp_entity_id%
-            sso_url: %saml_remote_idp_sso_url%
-            certificate: %saml_remote_idp_certificate%
+            entity_id: "%saml_remote_idp_entity_id%"
+            sso_url: "%saml_remote_idp_sso_url%"
+            certificate: "%saml_remote_idp_certificate%"
 
 surfnet_stepup:
     logging:
         application_name: registration-authority
     loa_definition:
-        loa1: %stepup_loa_loa1%
-        loa2: %stepup_loa_loa2%
-        loa3: %stepup_loa_loa3%
+        loa1: "%stepup_loa_loa1%"
+        loa2: "%stepup_loa_loa2%"
+        loa3: "%stepup_loa_loa3%"
     sms:
-        originator: %sms_originator%
-        otp_expiry_interval: %sms_otp_expiry_interval%
-        maximum_otp_requests: %sms_maximum_otp_requests%
+        originator: "%sms_originator%"
+        otp_expiry_interval: "%sms_otp_expiry_interval%"
+        maximum_otp_requests: "%sms_maximum_otp_requests%"
     gateway_api:
-        url: %gateway_api_url%
+        url: "%gateway_api_url%"
         credentials:
-            username: %gateway_api_username%
-            password: %gateway_api_password%
+            username: "%gateway_api_username%"
+            password: "%gateway_api_password%"
     attach_request_id_injector_to:
         - surfnet_stepup.guzzle.gateway_api
         - surfnet_stepup_middleware_client.guzzle.api
         - surfnet_stepup_middleware_client.guzzle.commands
     locale_cookie:
-        domain: %locale_cookie_domain%
+        domain: "%locale_cookie_domain%"
 
 jms_translation:
-    locales: %locales%
+    locales: "%locales%"
     configs:
         default:
-            dirs: [%kernel.root_dir%/../src, %kernel.root_dir%, %kernel.root_dir%/../vendor/surfnet/stepup-middleware-client-bundle, %kernel.root_dir%/../vendor/surfnet/stepup-bundle]
-            output_dir: %kernel.root_dir%/Resources/translations
+            dirs: ["%kernel.root_dir%/../src", "%kernel.root_dir%", "%kernel.root_dir%/../vendor/surfnet/stepup-middleware-client-bundle", "%kernel.root_dir%/../vendor/surfnet/stepup-bundle"]
+            output_dir: "%kernel.root_dir%/Resources/translations"
             ignored_domains: []
             excluded_names: ['*TestCase.php', '*Test.php']
             excluded_dirs: [cache, data, logs, Tests]
@@ -163,4 +162,4 @@ knp_paginator:
         sortable: SurfnetStepupRaRaBundle:Pagination:sortable_link.html.twig
 
 surfnet_stepup_u2f:
-    app_id: %u2f_app_id%
+    app_id: "%u2f_app_id%"

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -31,7 +31,7 @@ monolog:
             type: stream
             handler: logfile
             level: NOTICE
-            path: %kernel.logs_dir%/%kernel.environment%.log
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
 
 assetic:
     use_controller: "%use_assetic_controller%"

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -6,10 +6,6 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
-_configurator:
-    resource: "@SensioDistributionBundle/Resources/config/routing/webconfigurator.xml"
-    prefix:   /_configurator
-
 JMSTranslationBundle_ui:
     resource: "@JMSTranslationBundle/Controller/"
     type:     annotation

--- a/app/config/samlstepupproviders.yml
+++ b/app/config/samlstepupproviders.yml
@@ -5,40 +5,23 @@ surfnet_stepup_ra_saml_stepup_provider:
     routes:
         consume_assertion: ra_vetting_gssf_verify
         metadata: ra_vetting_gssf_metadata
+
     providers:
         tiqr:
             hosted:
                 service_provider:
-                    public_key: %gssp_tiqr_sp_publickey%
-                    private_key: %gssp_tiqr_sp_privatekey%
+                    public_key: "%gssp_tiqr_sp_publickey%"
+                    private_key: "%gssp_tiqr_sp_privatekey%"
                 metadata:
-                    public_key: %gssp_tiqr_metadata_publickey%
-                    private_key: %gssp_tiqr_metadata_privatekey%
+                    public_key: "%gssp_tiqr_metadata_publickey%"
+                    private_key: "%gssp_tiqr_metadata_privatekey%"
             remote:
-                entity_id: %gssp_tiqr_remote_entity_id%
-                sso_url: %gssp_tiqr_remote_sso_url%
-                certificate: %gssp_tiqr_remote_certificate%
+                entity_id: "%gssp_tiqr_remote_entity_id%"
+                sso_url: "%gssp_tiqr_remote_sso_url%"
+                certificate: "%gssp_tiqr_remote_certificate%"
             view_config:
-                title: %gssp_tiqr_title%
-                page_title: %gssp_tiqr_page_title%
-                explanation: %gssp_tiqr_explanation%
-                initiate: %gssp_tiqr_initiate%
-                gssf_id_mismatch: %gssp_tiqr_gssf_id_mismatch%
-        biometric:
-            hosted:
-                service_provider:
-                    public_key: %gssp_biometric_sp_publickey%
-                    private_key: %gssp_biometric_sp_privatekey%
-                metadata:
-                    public_key: %gssp_biometric_metadata_publickey%
-                    private_key: %gssp_biometric_metadata_privatekey%
-            remote:
-                entity_id: %gssp_biometric_remote_entity_id%
-                sso_url: %gssp_biometric_remote_sso_url%
-                certificate: %gssp_biometric_remote_certificate%
-            view_config:
-                title: %gssp_biometric_title%
-                page_title: %gssp_biometric_page_title%
-                explanation: %gssp_biometric_explanation%
-                initiate: %gssp_biometric_initiate%
-                gssf_id_mismatch: %gssp_biometric_gssf_id_mismatch%
+                title: "%gssp_tiqr_title%"
+                page_title: "%gssp_tiqr_page_title%"
+                explanation: "%gssp_tiqr_explanation%"
+                initiate: "%gssp_tiqr_initiate%"
+                gssf_id_mismatch: "%gssp_tiqr_gssf_id_mismatch%"

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -10,6 +10,7 @@ security:
 
         default:
             pattern: ^/authentication/(metadata|session-expired)$
+            logout_on_user_change: true
             anonymous: ~
 
         monitor:
@@ -22,11 +23,12 @@ security:
 
         saml_based:
             saml: true
+            logout_on_user_change: true
             logout:
                 path: /logout
-                target: %logout_redirect_url%
+                target: "%logout_redirect_url%"
                 invalidate_session: true
-                csrf_token_generator: form.csrf_provider
+                csrf_token_generator: security.csrf.token_manager
                 csrf_parameter: 't'
                 csrf_token_id: 'registration_authority_logout_token'
 

--- a/app/console
+++ b/app/console
@@ -1,23 +1,26 @@
 #!/usr/bin/env php
 <?php
 
-set_time_limit(0);
-
-require_once __DIR__.'/bootstrap.php.cache';
-require_once __DIR__.'/AppKernel.php';
-
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
+// if you don't want to setup permissions the proper way, just uncomment the following PHP line
+// read http://symfony.com/doc/current/setup.html#checking-symfony-application-configuration-and-setup
+// for more information
+//umask(0000);
+
+set_time_limit(0);
+
+/** @var Composer\Autoload\ClassLoader $loader */
+$loader = require __DIR__.'/../app/autoload.php';
+
 $input = new ArgvInput();
-$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', ''))
-    && $env !== 'prod'
-    && $env !== 'build';
+$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $env !== 'prod';
 
 if ($debug) {
-    Debug::enable(~E_USER_DEPRECATED);
+    Debug::enable();
 }
 
 $kernel = new AppKernel($env, $debug);

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -13,4 +13,13 @@
             <directory>../src/Surfnet/StepupRa/SamlStepupProviderBundle/Tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>../src</directory>
+            <exclude>
+                <directory>../src/Surfnet/StepupRa/RaBundle/Tests</directory>
+                <directory>../src/Surfnet/StepupRa/SamlStepupProviderBundle/Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/app/symfony_requirements
+++ b/app/symfony_requirements
@@ -1,0 +1,146 @@
+#!/usr/bin/env php
+<?php
+
+require_once dirname(__FILE__).'/./SymfonyRequirements.php';
+
+$lineSize = 70;
+$symfonyRequirements = new SymfonyRequirements();
+$iniPath = $symfonyRequirements->getPhpIniConfigPath();
+
+echo_title('Symfony Requirements Checker');
+
+echo '> PHP is using the following php.ini file:'.PHP_EOL;
+if ($iniPath) {
+    echo_style('green', '  '.$iniPath);
+} else {
+    echo_style('yellow', '  WARNING: No configuration file (php.ini) used by PHP!');
+}
+
+echo PHP_EOL.PHP_EOL;
+
+echo '> Checking Symfony requirements:'.PHP_EOL.'  ';
+
+$messages = array();
+foreach ($symfonyRequirements->getRequirements() as $req) {
+    if ($helpText = get_error_message($req, $lineSize)) {
+        echo_style('red', 'E');
+        $messages['error'][] = $helpText;
+    } else {
+        echo_style('green', '.');
+    }
+}
+
+$checkPassed = empty($messages['error']);
+
+foreach ($symfonyRequirements->getRecommendations() as $req) {
+    if ($helpText = get_error_message($req, $lineSize)) {
+        echo_style('yellow', 'W');
+        $messages['warning'][] = $helpText;
+    } else {
+        echo_style('green', '.');
+    }
+}
+
+if ($checkPassed) {
+    echo_block('success', 'OK', 'Your system is ready to run Symfony projects');
+} else {
+    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony projects');
+
+    echo_title('Fix the following mandatory requirements', 'red');
+
+    foreach ($messages['error'] as $helpText) {
+        echo ' * '.$helpText.PHP_EOL;
+    }
+}
+
+if (!empty($messages['warning'])) {
+    echo_title('Optional recommendations to improve your setup', 'yellow');
+
+    foreach ($messages['warning'] as $helpText) {
+        echo ' * '.$helpText.PHP_EOL;
+    }
+}
+
+echo PHP_EOL;
+echo_style('title', 'Note');
+echo '  The command console could use a different php.ini file'.PHP_EOL;
+echo_style('title', '~~~~');
+echo '  than the one used with your web server. To be on the'.PHP_EOL;
+echo '      safe side, please check the requirements from your web'.PHP_EOL;
+echo '      server using the ';
+echo_style('yellow', 'web/config.php');
+echo ' script.'.PHP_EOL;
+echo PHP_EOL;
+
+exit($checkPassed ? 0 : 1);
+
+function get_error_message(Requirement $requirement, $lineSize)
+{
+    if ($requirement->isFulfilled()) {
+        return;
+    }
+
+    $errorMessage = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
+    $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
+
+    return $errorMessage;
+}
+
+function echo_title($title, $style = null)
+{
+    $style = $style ?: 'title';
+
+    echo PHP_EOL;
+    echo_style($style, $title.PHP_EOL);
+    echo_style($style, str_repeat('~', strlen($title)).PHP_EOL);
+    echo PHP_EOL;
+}
+
+function echo_style($style, $message)
+{
+    // ANSI color codes
+    $styles = array(
+        'reset' => "\033[0m",
+        'red' => "\033[31m",
+        'green' => "\033[32m",
+        'yellow' => "\033[33m",
+        'error' => "\033[37;41m",
+        'success' => "\033[37;42m",
+        'title' => "\033[34m",
+    );
+    $supports = has_color_support();
+
+    echo($supports ? $styles[$style] : '').$message.($supports ? $styles['reset'] : '');
+}
+
+function echo_block($style, $title, $message)
+{
+    $message = ' '.trim($message).' ';
+    $width = strlen($message);
+
+    echo PHP_EOL.PHP_EOL;
+
+    echo_style($style, str_repeat(' ', $width));
+    echo PHP_EOL;
+    echo_style($style, str_pad(' ['.$title.']', $width, ' ', STR_PAD_RIGHT));
+    echo PHP_EOL;
+    echo_style($style, $message);
+    echo PHP_EOL;
+    echo_style($style, str_repeat(' ', $width));
+    echo PHP_EOL;
+}
+
+function has_color_support()
+{
+    static $support;
+
+    if (null === $support) {
+        if (DIRECTORY_SEPARATOR == '\\') {
+            $support = false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI');
+        } else {
+            $support = function_exists('posix_isatty') && @posix_isatty(STDOUT);
+        }
+    }
+
+    return $support;
+}

--- a/app_dev.php.dist
+++ b/app_dev.php.dist
@@ -1,12 +1,11 @@
 <?php
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
-
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+use Symfony\Component\HttpFoundation\Request;
+$loader = require __DIR__.'/../app/autoload.php';
 Debug::enable(~E_USER_DEPRECATED);
 
-require_once __DIR__.'/../app/AppKernel.php';
+$request = Request::createFromGlobals();
 
 $env = 'dev';
 if (isset($_SERVER['APP_DEV'])) {
@@ -14,9 +13,11 @@ if (isset($_SERVER['APP_DEV'])) {
 }
 
 $kernel = new AppKernel($env, true);
-$kernel->loadClassCache();
+$kernel->boot();
 
-$request = Request::createFromGlobals();
+$trustedProxies = $kernel->getContainer()->getParameter('trusted_proxies');
+Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_ALL);
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/composer.json
+++ b/composer.json
@@ -5,44 +5,49 @@
     "autoload": {
         "psr-4": {
             "Surfnet\\": "src\\Surfnet"
-        }
+        },
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppCache.php"
+        ]
     },
     "minimum-stability": "stable",
     "require": {
         "php": "~5.6|~7.0",
-        "symfony/symfony": "~2.7.0",
-        "twig/extensions": "~1.0",
+        "symfony/symfony": "3.4.*",
+        "twig/twig": "^1.35",
+        "twig/extensions": "~1.5",
         "symfony/assetic-bundle": "~2.3",
-        "symfony/monolog-bundle": "~2.4",
-        "sensio/distribution-bundle": "~3.0",
+        "symfony/monolog-bundle": "~3.1.0",
+        "sensio/distribution-bundle": "~5.0",
         "sensio/framework-extra-bundle": "~3.0",
         "incenteev/composer-parameter-handler": "~2.0",
         "nelmio/security-bundle": "~1.6",
-        "mopa/bootstrap-bundle": "3.0.0-RC2",
-        "twbs/bootstrap": "~3.2.0",
+        "mopa/bootstrap-bundle": "^3.2",
+        "twbs/bootstrap": "~3.3.0",
         "fortawesome/font-awesome": "~4.2.0",
         "jms/translation-bundle": "~1.3.0",
-        "jms/di-extra-bundle": "~1.4.0",
-        "surfnet/stepup-middleware-client-bundle": "^2.0",
-        "surfnet/stepup-bundle": "^3.4.0",
+        "surfnet/stepup-middleware-client-bundle": "^2.4",
+        "surfnet/stepup-saml-bundle": "^4.1",
+        "surfnet/stepup-bundle": "^4.0",
         "surfnet/stepup-u2f-bundle": "dev-develop",
+        "openconext/monitor-bundle": "^1.0",
         "guzzlehttp/guzzle": "^6",
         "knplabs/knp-paginator-bundle": "~2.4",
         "mopa/composer-bridge": "~1.5",
         "ramsey/uuid": "^3.5",
-        "ee/dataexporter-bundle": "^0.4.2",
-        "openconext/monitor-bundle": "^1.0",
-        "surfnet/stepup-saml-bundle": "^4.0"
+        "ee/dataexporter-bundle": "dev-feature/syfony-3-and-4-support"
     },
     "require-dev": {
-        "sensio/generator-bundle": "~2.3",
-        "matthiasnoback/symfony-config-test": "^1.2",
-        "mockery/mockery": "^0.9.5",
-        "phpmd/phpmd": "^2.0",
-        "phpunit/phpunit": "^4.0",
-        "sensiolabs/security-checker": "^2.0",
+        "matthiasnoback/symfony-config-test": "^2.2",
+        "mockery/mockery": "~1.0",
+        "phpmd/phpmd": "^2.6",
+        "phpunit/phpunit": "^5.7",
+        "sebastian/exporter": "~2.0",
+        "sensiolabs/security-checker": "^3.0",
         "sebastian/phpcpd": "^2.0",
-        "squizlabs/php_codesniffer": "^1.0"
+        "squizlabs/php_codesniffer": "^1.0",
+        "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {
         "post-install-cmd": [
@@ -62,8 +67,13 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles"
         ]
     },
+    "config": {
+        "optimize-autoloader": true
+    },
     "extra": {
         "symfony-app-dir": "app",
+        "symfony-var-dir": "app",
+        "symfony-bin-dir": "app",
         "symfony-web-dir": "web",
         "symfony-assets-install": "relative",
         "incenteev-parameters": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f632ef9c9e9bc0dd2a7638367388172",
+    "content-hash": "8c2338bd231e7789752c7f5203555bb4",
     "packages": [
         {
             "name": "beberlei/assert",
-            "version": "v2.5.1",
+            "version": "v2.9.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beberlei/assert.git",
-                "reference": "8a9ad22f1220e47a6d174843e8abef08f5eac441"
+                "reference": "ec9e4cf0b63890edce844ee3922e2b95a526e936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beberlei/assert/zipball/8a9ad22f1220e47a6d174843e8abef08f5eac441",
-                "reference": "8a9ad22f1220e47a6d174843e8abef08f5eac441",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/ec9e4cf0b63890edce844ee3922e2b95a526e936",
+                "reference": "ec9e4cf0b63890edce844ee3922e2b95a526e936",
                 "shasum": ""
             },
             "require": {
@@ -25,17 +25,13 @@
                 "php": ">=5.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "@stable"
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4.8.35|^5.7"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Assert": "lib/"
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
                 },
                 "files": [
                     "lib/Assert/functions.php"
@@ -48,7 +44,13 @@
             "authors": [
                 {
                     "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
                 }
             ],
             "description": "Thin assertion library for input validation in business models.",
@@ -57,39 +59,39 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2016-06-20T12:01:28+00:00"
+            "time": "2018-06-11T17:15:25+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.2.7",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Annotations\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -125,20 +127,20 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31T12:32:49+00:00"
+            "time": "2017-02-24T16:22:25+00:00"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b",
                 "shasum": ""
             },
             "require": {
@@ -195,32 +197,33 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31T16:37:02+00:00"
+            "time": "2017-07-22T12:49:21+00:00"
         },
         {
             "name": "doctrine/collections",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
-                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -261,20 +264,20 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14T22:21:58+00:00"
+            "time": "2017-01-03T10:49:41+00:00"
         },
         {
             "name": "doctrine/common",
-            "version": "v2.6.1",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
-                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9",
                 "shasum": ""
             },
             "require": {
@@ -283,10 +286,10 @@
                 "doctrine/collections": "1.*",
                 "doctrine/inflector": "1.*",
                 "doctrine/lexer": "1.*",
-                "php": "~5.5|~7.0"
+                "php": "~5.6|~7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8|~5.0"
+                "phpunit/phpunit": "^5.4.6"
             },
             "type": "library",
             "extra": {
@@ -334,7 +337,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25T13:18:31+00:00"
+            "time": "2017-07-22T08:35:12+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -459,24 +462,24 @@
         },
         {
             "name": "ee/dataexporter-bundle",
-            "version": "v0.4.2",
+            "version": "dev-feature/syfony-3-and-4-support",
             "target-dir": "EE/DataExporterBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/EE/DataExporter.git",
-                "reference": "c0f78ab21dc1752ff9232b8f24d0976459b6330d"
+                "url": "https://github.com/MKodde/DataExporter.git",
+                "reference": "ab440e69af642fbc5c9535197b677410b5a3aba3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EE/DataExporter/zipball/c0f78ab21dc1752ff9232b8f24d0976459b6330d",
-                "reference": "c0f78ab21dc1752ff9232b8f24d0976459b6330d",
+                "url": "https://api.github.com/repos/MKodde/DataExporter/zipball/ab440e69af642fbc5c9535197b677410b5a3aba3",
+                "reference": "ab440e69af642fbc5c9535197b677410b5a3aba3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.1",
-                "symfony/http-foundation": "~2.1",
-                "symfony/property-access": "~2.1"
+                "symfony/framework-bundle": ">=2.1,<5",
+                "symfony/http-foundation": ">=2.1,<5",
+                "symfony/property-access": ">=2.1,<5"
             },
             "require-dev": {
                 "symfony/yaml": "~2.1"
@@ -487,7 +490,6 @@
                     "EE\\DataExporterBundle": ""
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -508,7 +510,64 @@
                 "xls",
                 "xml"
             ],
-            "time": "2013-06-27T18:50:02+00:00"
+            "support": {
+                "source": "https://github.com/MKodde/DataExporter/tree/feature/syfony-3-and-4-support"
+            },
+            "time": "2018-08-24T07:02:26+00:00"
+        },
+        {
+            "name": "fig/link-util",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link-util.git",
+                "reference": "1a07821801a148be4add11ab0603e4af55a72fac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link-util/zipball/1a07821801a148be4add11ab0603e4af55a72fac",
+                "reference": "1a07821801a148be4add11ab0603e4af55a72fac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0",
+                "psr/link": "~1.0@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.1",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common utility implementations for HTTP links",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "time": "2016-10-17T18:31:11+00:00"
         },
         {
             "name": "fortawesome/font-awesome",
@@ -560,16 +619,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.3",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
@@ -579,13 +638,16 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "6.3-dev"
                 }
             },
             "autoload": {
@@ -618,7 +680,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28T22:50:30+00:00"
+            "time": "2018-04-22T15:46:56+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -673,16 +735,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "0d6c7ca039329247e4f0f8f8f6506810e8248855"
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/0d6c7ca039329247e4f0f8f8f6506810e8248855",
-                "reference": "0d6c7ca039329247e4f0f8f8f6506810e8248855",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
                 "shasum": ""
             },
             "require": {
@@ -734,30 +796,30 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-02-27T10:51:17+00:00"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
-            "version": "v2.1.2",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Incenteev/ParameterHandler.git",
-                "reference": "d7ce7f06136109e81d1cb9d57066c4d4a99cf1cc"
+                "reference": "933c45a34814f27f2345c11c37d46b3ca7303550"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Incenteev/ParameterHandler/zipball/d7ce7f06136109e81d1cb9d57066c4d4a99cf1cc",
-                "reference": "d7ce7f06136109e81d1cb9d57066c4d4a99cf1cc",
+                "url": "https://api.github.com/repos/Incenteev/ParameterHandler/zipball/933c45a34814f27f2345c11c37d46b3ca7303550",
+                "reference": "933c45a34814f27f2345c11c37d46b3ca7303550",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "symfony/yaml": "~2.3|~3.0"
+                "symfony/yaml": "^2.3 || ^3.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpspec/prophecy-phpunit": "~1.0",
-                "symfony/filesystem": "~2.2"
+                "composer/composer": "^1.0@dev",
+                "symfony/filesystem": "^2.3 || ^3 || ^4",
+                "symfony/phpunit-bridge": "^4.0"
             },
             "type": "library",
             "extra": {
@@ -785,217 +847,7 @@
             "keywords": [
                 "parameters management"
             ],
-            "time": "2015-11-10T17:04:01+00:00"
-        },
-        {
-            "name": "jms/aop-bundle",
-            "version": "1.1.0",
-            "target-dir": "JMS/AopBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/JMSAopBundle.git",
-                "reference": "66287749c020b4c667c0ff4937b07e66c04bbe71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSAopBundle/zipball/66287749c020b4c667c0ff4937b07e66c04bbe71",
-                "reference": "66287749c020b4c667c0ff4937b07e66c04bbe71",
-                "shasum": ""
-            },
-            "require": {
-                "jms/cg": "^1.1",
-                "symfony/framework-bundle": "2.*"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "JMS\\AopBundle": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Adds AOP capabilities to Symfony2",
-            "keywords": [
-                "annotations",
-                "aop"
-            ],
-            "time": "2015-09-13T09:02:33+00:00"
-        },
-        {
-            "name": "jms/cg",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/cg-library.git",
-                "reference": "0af1113c7409b8636c5244bbae10b2e0ff792e9c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/cg-library/zipball/0af1113c7409b8636c5244bbae10b2e0ff792e9c",
-                "reference": "0af1113c7409b8636c5244bbae10b2e0ff792e9c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "CG\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache2"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Toolset for generating PHP code",
-            "keywords": [
-                "code generation"
-            ],
-            "time": "2015-09-13T08:54:43+00:00"
-        },
-        {
-            "name": "jms/di-extra-bundle",
-            "version": "1.4.0",
-            "target-dir": "JMS/DiExtraBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/JMSDiExtraBundle.git",
-                "reference": "7fffdb6c96fb922a131af06d773e1e6c5301d070"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/JMSDiExtraBundle/zipball/7fffdb6c96fb922a131af06d773e1e6c5301d070",
-                "reference": "7fffdb6c96fb922a131af06d773e1e6c5301d070",
-                "shasum": ""
-            },
-            "require": {
-                "jms/aop-bundle": ">=1.0.0,<1.2-dev",
-                "jms/metadata": "1.*",
-                "symfony/finder": "~2.1",
-                "symfony/framework-bundle": "~2.1",
-                "symfony/process": "~2.1"
-            },
-            "require-dev": {
-                "doctrine/doctrine-bundle": "*",
-                "doctrine/orm": "*",
-                "jms/security-extra-bundle": "1.*",
-                "phpcollection/phpcollection": ">=0.1,<0.3-dev",
-                "sensio/framework-extra-bundle": "*",
-                "symfony/browser-kit": "*",
-                "symfony/class-loader": "*",
-                "symfony/form": "*",
-                "symfony/security-bundle": "*",
-                "symfony/twig-bundle": "*",
-                "symfony/validator": "*",
-                "symfony/yaml": "*"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "JMS\\DiExtraBundle": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
-                    "role": "Developer of wrapped JMSSerializerBundle"
-                }
-            ],
-            "description": "Allows to configure dependency injection using annotations",
-            "homepage": "http://jmsyst.com/bundles/JMSDiExtraBundle",
-            "keywords": [
-                "annotations",
-                "dependency injection"
-            ],
-            "time": "2013-06-08T13:13:40+00:00"
-        },
-        {
-            "name": "jms/metadata",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schmittjoh/metadata.git",
-                "reference": "22b72455559a25777cfd28c4ffda81ff7639f353"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/22b72455559a25777cfd28c4ffda81ff7639f353",
-                "reference": "22b72455559a25777cfd28c4ffda81ff7639f353",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "doctrine/cache": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Metadata\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache"
-            ],
-            "authors": [
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
-                    "role": "Developer of wrapped JMSSerializerBundle"
-                }
-            ],
-            "description": "Class/method/property metadata management in PHP",
-            "keywords": [
-                "annotations",
-                "metadata",
-                "xml",
-                "yaml"
-            ],
-            "time": "2014-07-12T07:13:19+00:00"
+            "time": "2018-02-13T18:05:56+00:00"
         },
         {
             "name": "jms/translation-bundle",
@@ -1066,16 +918,16 @@
         },
         {
             "name": "knplabs/knp-components",
-            "version": "1.3.3",
+            "version": "v1.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/knp-components.git",
-                "reference": "bc49e739d1cce94d783b1e23bc5b263b38dc47da"
+                "reference": "f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/bc49e739d1cce94d783b1e23bc5b263b38dc47da",
-                "reference": "bc49e739d1cce94d783b1e23bc5b263b38dc47da",
+                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266",
+                "reference": "f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266",
                 "shasum": ""
             },
             "require": {
@@ -1088,16 +940,11 @@
                 "jackalope/jackalope-doctrine-dbal": "~1.2",
                 "phpunit/phpunit": "~4.2",
                 "ruflin/elastica": "~1.0",
-                "symfony/event-dispatcher": "~2.5"
+                "symfony/event-dispatcher": "~2.5",
+                "symfony/property-access": ">=2.3"
             },
             "suggest": {
-                "doctrine/common": "to allow usage pagination with Doctrine ArrayCollection",
-                "doctrine/mongodb-odm": "to allow usage pagination with Doctrine ODM MongoDB",
-                "doctrine/orm": "to allow usage pagination with Doctrine ORM",
-                "doctrine/phpcr-odm": "to allow usage pagination with Doctrine ODM PHPCR",
-                "propel/propel1": "to allow usage pagination with Propel ORM",
-                "ruflin/Elastica": "to allow usage pagination with ElasticSearch Client",
-                "solarium/solarium": "to allow usage pagination with Solarium Client"
+                "symfony/property-access": "To allow sorting arrays"
             },
             "type": "library",
             "extra": {
@@ -1133,35 +980,36 @@
                 "pager",
                 "paginator"
             ],
-            "time": "2016-04-21T06:26:20+00:00"
+            "time": "2018-08-03T08:37:27+00:00"
         },
         {
             "name": "knplabs/knp-paginator-bundle",
-            "version": "2.5.3",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/KnpPaginatorBundle.git",
-                "reference": "c988761005504007c6c87d6a557641281194a0e5"
+                "reference": "f4ece5b347121b9fe13166264f197f90252d4bd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpPaginatorBundle/zipball/c988761005504007c6c87d6a557641281194a0e5",
-                "reference": "c988761005504007c6c87d6a557641281194a0e5",
+                "url": "https://api.github.com/repos/KnpLabs/KnpPaginatorBundle/zipball/f4ece5b347121b9fe13166264f197f90252d4bd2",
+                "reference": "f4ece5b347121b9fe13166264f197f90252d4bd2",
                 "shasum": ""
             },
             "require": {
                 "knplabs/knp-components": "~1.2",
                 "php": ">=5.3.3",
-                "symfony/framework-bundle": "~2.3|~3.0",
+                "symfony/framework-bundle": "~2.7|~3.0|~4.0",
                 "twig/twig": "~1.12|~2"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.4|~3.0"
+                "phpunit/phpunit": "~4.8.35|~5.4.3|~6.4",
+                "symfony/expression-language": "~2.7|~3.0|~4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5.x-dev"
+                    "dev-master": "2.8.x-dev"
                 }
             },
             "autoload": {
@@ -1179,35 +1027,35 @@
                     "homepage": "http://knplabs.com"
                 },
                 {
-                    "name": "Symfony2 Community",
+                    "name": "Symfony Community",
                     "homepage": "http://github.com/KnpLabs/KnpPaginatorBundle/contributors"
                 }
             ],
-            "description": "Paginator bundle for Symfony2 to automate pagination and simplify sorting and other features",
+            "description": "Paginator bundle for Symfony to automate pagination and simplify sorting and other features",
             "homepage": "http://github.com/KnpLabs/KnpPaginatorBundle",
             "keywords": [
-                "Symfony2",
                 "bundle",
                 "knp",
                 "knplabs",
                 "pager",
                 "pagination",
-                "paginator"
+                "paginator",
+                "symfony"
             ],
-            "time": "2016-04-20T11:40:30+00:00"
+            "time": "2018-05-16T12:15:58+00:00"
         },
         {
             "name": "kriswallsmith/assetic",
-            "version": "v1.3.2",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kriswallsmith/assetic.git",
-                "reference": "9928f7c4ad98b234e3559d1049abd13387f86db5"
+                "reference": "e911c437dbdf006a8f62c2f59b15b2d69a5e0aa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/9928f7c4ad98b234e3559d1049abd13387f86db5",
-                "reference": "9928f7c4ad98b234e3559d1049abd13387f86db5",
+                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/e911c437dbdf006a8f62c2f59b15b2d69a5e0aa1",
+                "reference": "e911c437dbdf006a8f62c2f59b15b2d69a5e0aa1",
                 "shasum": ""
             },
             "require": {
@@ -1215,21 +1063,21 @@
                 "symfony/process": "~2.1|~3.0"
             },
             "conflict": {
-                "twig/twig": "<1.23"
+                "twig/twig": "<1.27"
             },
             "require-dev": {
-                "cssmin/cssmin": "3.0.1",
-                "joliclic/javascript-packer": "1.1",
-                "kamicane/packager": "1.0",
                 "leafo/lessphp": "^0.3.7",
                 "leafo/scssphp": "~0.1",
-                "mrclay/minify": "~2.2",
+                "meenie/javascript-packer": "^1.1",
+                "mrclay/minify": "<2.3",
+                "natxet/cssmin": "3.0.4",
                 "patchwork/jsqueeze": "~1.0|~2.0",
-                "phpunit/phpunit": "~4.8",
+                "phpunit/phpunit": "~4.8 || ^5.6",
                 "psr/log": "~1.0",
                 "ptachoire/cssembed": "~1.0",
                 "symfony/phpunit-bridge": "~2.7|~3.0",
-                "twig/twig": "~1.8|~2.0"
+                "twig/twig": "~1.23|~2.0",
+                "yfix/packager": "dev-master"
             },
             "suggest": {
                 "leafo/lessphp": "Assetic provides the integration with the lessphp LESS compiler",
@@ -1271,20 +1119,20 @@
                 "compression",
                 "minification"
             ],
-            "time": "2015-11-12T13:51:40+00:00"
+            "time": "2016-11-11T18:43:20+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "1.19.0",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf"
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf",
-                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
                 "shasum": ""
             },
             "require": {
@@ -1295,7 +1143,7 @@
                 "psr/log-implementation": "1.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9",
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
                 "jakub-onderka/php-parallel-lint": "0.9",
@@ -1303,9 +1151,9 @@
                 "php-console/php-console": "^3.1.3",
                 "phpunit/phpunit": "~4.5",
                 "phpunit/phpunit-mock-objects": "2.3.0",
-                "raven/raven": "^0.13",
                 "ruflin/elastica": ">=0.90 <3.0",
-                "swiftmailer/swiftmailer": "~5.3"
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
@@ -1316,9 +1164,9 @@
                 "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "raven/raven": "Allow sending log messages to a Sentry server",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
             },
             "type": "library",
             "extra": {
@@ -1349,72 +1197,87 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-04-12T18:29:35+00:00"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "moontoast/math",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/moontoast-math.git",
-                "reference": "fce28a9d1e73e73376cb44e5e581675d15fbe2f3"
+                "reference": "c2792a25df5cad4ff3d760dd37078fc5b6fccc79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/moontoast-math/zipball/fce28a9d1e73e73376cb44e5e581675d15fbe2f3",
-                "reference": "fce28a9d1e73e73376cb44e5e581675d15fbe2f3",
+                "url": "https://api.github.com/repos/ramsey/moontoast-math/zipball/c2792a25df5cad4ff3d760dd37078fc5b6fccc79",
+                "reference": "c2792a25df5cad4ff3d760dd37078fc5b6fccc79",
                 "shasum": ""
             },
             "require": {
                 "ext-bcmath": "*",
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^0.9.0",
+                "phpunit/phpunit": "^4.7|>=5.0 <5.4",
+                "satooshi/php-coveralls": "^0.6.1",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Moontoast\\Math": "src/"
+                "psr-4": {
+                    "Moontoast\\Math\\": "src/Moontoast/Math/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
             "description": "A mathematics library, providing functionality for large numbers",
-            "homepage": "https://github.com/moontoast/math",
+            "homepage": "https://github.com/ramsey/moontoast-math",
             "keywords": [
                 "bcmath",
                 "math"
             ],
-            "time": "2013-01-19T17:42:34+00:00"
+            "time": "2017-02-16T16:54:46+00:00"
         },
         {
             "name": "mopa/bootstrap-bundle",
-            "version": "v3.0.0-RC2",
+            "version": "v3.2.2",
             "target-dir": "Mopa/Bundle/BootstrapBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phiamo/MopaBootstrapBundle.git",
-                "reference": "c43c1c3b230cccfaa2548b55a7ddca5a5af8eaff"
+                "reference": "d30a6d807c582c606d8fc138dba6584dea559849"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phiamo/MopaBootstrapBundle/zipball/c43c1c3b230cccfaa2548b55a7ddca5a5af8eaff",
-                "reference": "c43c1c3b230cccfaa2548b55a7ddca5a5af8eaff",
+                "url": "https://api.github.com/repos/phiamo/MopaBootstrapBundle/zipball/d30a6d807c582c606d8fc138dba6584dea559849",
+                "reference": "d30a6d807c582c606d8fc138dba6584dea559849",
                 "shasum": ""
             },
             "require": {
                 "mopa/composer-bridge": "~1.3",
-                "symfony/console": "~2.3",
-                "symfony/form": "~2.3|~3.0",
-                "symfony/framework-bundle": "~2.3",
-                "symfony/twig-bundle": "~2.3|~3.0",
-                "twig/twig": "^1.14.2"
+                "symfony/console": "~2.3|~3.0|^4.0",
+                "symfony/form": "~2.3|~3.0|^4.0",
+                "symfony/framework-bundle": "~2.3|~3.0|^4.0",
+                "symfony/twig-bundle": "~2.3|~3.0|^4.0",
+                "twig/twig": "^1.14.2|^2.0"
             },
             "conflict": {
                 "symfony/twig-bridge": "<2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.6"
+                "phpunit/phpunit": "~6.0",
+                "symfony/security-bundle": "~2.3|~3.0|^4.0",
+                "symfony/translation": "~2.3|~3.0|^4.0"
             },
             "suggest": {
                 "craue/formflow-bundle": "~2.0",
@@ -1457,7 +1320,7 @@
                 "form",
                 "template"
             ],
-            "time": "2015-09-10T17:23:40+00:00"
+            "time": "2017-12-23T16:45:33+00:00"
         },
         {
             "name": "mopa/composer-bridge",
@@ -1564,16 +1427,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.3",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda"
+                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/579f4ce846734a1cf55d6a531d00ca07a43e3cda",
-                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
+                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
                 "shasum": ""
             },
             "require": {
@@ -1611,20 +1474,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-12-26T14:43:21+00:00"
+            "time": "2018-02-28T20:30:58+00:00"
         },
         {
             "name": "openconext/monitor-bundle",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Monitor-bundle.git",
-                "reference": "b9be093828385e857ff23a106b4429155d7f8d58"
+                "reference": "1455a292376a03e28465195202c572aa243f0ddb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/b9be093828385e857ff23a106b4429155d7f8d58",
-                "reference": "b9be093828385e857ff23a106b4429155d7f8d58",
+                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/1455a292376a03e28465195202c572aa243f0ddb",
+                "reference": "1455a292376a03e28465195202c572aa243f0ddb",
                 "shasum": ""
             },
             "require": {
@@ -1656,7 +1519,7 @@
             "license": [
                 "Apache-2.0"
             ],
-            "description": "A Symfony2 bundle that facilitates health and info endpoints to a Symfony application",
+            "description": "A Symfony 3 bundle that facilitates health and info endpoints to a Symfony application. The bundle is backwards compatible with Symfony 2 projects.",
             "keywords": [
                 "OpenConext",
                 "health",
@@ -1664,20 +1527,20 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2017-12-07T14:41:46+00:00"
+            "time": "2018-08-16T13:07:30+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.4.1",
+            "version": "v2.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
+                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
-                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
                 "shasum": ""
             },
             "require": {
@@ -1709,10 +1572,106 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-03-18T20:34:03+00:00"
+            "time": "2018-07-04T16:31:37+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1765,6 +1724,55 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
+            "name": "psr/link",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link.git",
+                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link/zipball/eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for HTTP links",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "time": "2016-10-28T16:06:13+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -1812,39 +1820,89 @@
             "time": "2016-10-10T12:19:37+00:00"
         },
         {
-            "name": "ramsey/uuid",
-            "version": "3.5.0",
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ramsey/uuid.git",
-                "reference": "a6d15c8618ea3951fd54d34e326b68d3d0bc0786"
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/a6d15c8618ea3951fd54d34e326b68d3d0bc0786",
-                "reference": "a6d15c8618ea3951fd54d34e326b68d3d0bc0786",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "^1.0|^2.0",
-                "php": ">=5.4"
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "^1.0|^2.0|9.99.99",
+                "php": "^5.4 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "apigen/apigen": "^4.1",
-                "codeception/aspect-mock": "1.0.0",
-                "goaop/framework": "1.0.0-alpha.2",
+                "codeception/aspect-mock": "^1.0 | ~2.0.0",
+                "doctrine/annotations": "~1.2.0",
+                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ~2.1.0",
                 "ircmaxell/random-lib": "^1.1",
                 "jakub-onderka/php-parallel-lint": "^0.9.0",
-                "mockery/mockery": "^0.9.4",
+                "mockery/mockery": "^0.9.9",
                 "moontoast/math": "^1.1",
-                "phpunit/phpunit": "^4.7|>=5.0 <5.4",
-                "satooshi/php-coveralls": "^0.6.1",
+                "php-mock/php-mock-phpunit": "^0.3|^1.1",
+                "phpunit/phpunit": "^4.7|^5.0|^6.5",
                 "squizlabs/php_codesniffer": "^2.3"
             },
             "suggest": {
+                "ext-ctype": "Provides support for PHP Ctype functions",
                 "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
                 "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
                 "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
@@ -1889,7 +1947,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-08-02T18:39:32+00:00"
+            "time": "2018-07-19T23:38:55+00:00"
         },
         {
             "name": "robrichards/xmlseclibs",
@@ -1933,45 +1991,37 @@
         },
         {
             "name": "sensio/distribution-bundle",
-            "version": "v3.0.30",
-            "target-dir": "Sensio/Bundle/DistributionBundle",
+            "version": "v5.0.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "f1758b30096202aeede61f79a1dffd69da091517"
+                "reference": "209b11f8cee5bf71986dd703e45e27d3ed7a6d15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/f1758b30096202aeede61f79a1dffd69da091517",
-                "reference": "f1758b30096202aeede61f79a1dffd69da091517",
+                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/209b11f8cee5bf71986dd703e45e27d3ed7a6d15",
+                "reference": "209b11f8cee5bf71986dd703e45e27d3ed7a6d15",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sensiolabs/security-checker": "~2.0",
-                "symfony/class-loader": "~2.2",
-                "symfony/framework-bundle": "~2.3",
-                "symfony/process": "~2.2"
-            },
-            "require-dev": {
-                "symfony/form": "~2.2",
-                "symfony/validator": "~2.2",
-                "symfony/yaml": "~2.2"
-            },
-            "suggest": {
-                "symfony/form": "If you want to use the configurator",
-                "symfony/validator": "If you want to use the configurator",
-                "symfony/yaml": "If you want to use  the configurator"
+                "php": ">=5.3.9",
+                "sensiolabs/security-checker": "~3.0|~4.0",
+                "symfony/class-loader": "~2.3|~3.0",
+                "symfony/config": "~2.3|~3.0",
+                "symfony/dependency-injection": "~2.3|~3.0",
+                "symfony/filesystem": "~2.3|~3.0",
+                "symfony/http-kernel": "~2.3|~3.0",
+                "symfony/process": "~2.3|~3.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Sensio\\Bundle\\DistributionBundle": ""
+                "psr-4": {
+                    "Sensio\\Bundle\\DistributionBundle\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1989,36 +2039,44 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2015-06-05T22:32:22+00:00"
+            "time": "2018-06-07T06:22:12+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.16",
+            "version": "v3.0.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "507a15f56fa7699f6cc8c2c7de4080b19ce22546"
+                "reference": "bb907234df776b68922eb4b25bfa061683597b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/507a15f56fa7699f6cc8c2c7de4080b19ce22546",
-                "reference": "507a15f56fa7699f6cc8c2c7de4080b19ce22546",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/bb907234df776b68922eb4b25bfa061683597b6a",
+                "reference": "bb907234df776b68922eb4b25bfa061683597b6a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "~2.2",
                 "symfony/dependency-injection": "~2.3|~3.0",
-                "symfony/framework-bundle": "~2.3|~3.0"
+                "symfony/framework-bundle": "~2.3|~3.0|~4.0"
             },
             "require-dev": {
-                "symfony/browser-kit": "~2.3|~3.0",
-                "symfony/dom-crawler": "~2.3|~3.0",
-                "symfony/expression-language": "~2.4|~3.0",
-                "symfony/finder": "~2.3|~3.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0",
-                "symfony/security-bundle": "~2.4|~3.0",
-                "symfony/twig-bundle": "~2.3|~3.0",
-                "twig/twig": "~1.11|~2.0"
+                "doctrine/doctrine-bundle": "~1.5",
+                "doctrine/orm": "~2.4,>=2.4.5",
+                "symfony/asset": "~2.7|~3.0|~4.0",
+                "symfony/browser-kit": "~2.3|~3.0|~4.0",
+                "symfony/dom-crawler": "~2.3|~3.0|~4.0",
+                "symfony/expression-language": "~2.4|~3.0|~4.0",
+                "symfony/finder": "~2.3|~3.0|~4.0",
+                "symfony/phpunit-bridge": "~3.2|~4.0",
+                "symfony/psr-http-message-bridge": "^0.3|^1.0",
+                "symfony/security-bundle": "~2.4|~3.0|~4.0",
+                "symfony/templating": "~2.3|~3.0|~4.0",
+                "symfony/translation": "~2.3|~3.0|~4.0",
+                "symfony/twig-bundle": "~2.3|~3.0|~4.0",
+                "symfony/yaml": "~2.3|~3.0|~4.0",
+                "twig/twig": "~1.12|~2.0",
+                "zendframework/zend-diactoros": "^1.3"
             },
             "suggest": {
                 "symfony/expression-language": "",
@@ -2051,25 +2109,24 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2016-03-25T17:08:27+00:00"
+            "time": "2017-12-14T19:03:23+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v2.0.5",
+            "version": "v3.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "2c2a71f1c77d9765c12638c4724d9ca23658a810"
+                "reference": "59a6a299e2f5612dc8692d40e84373703a5df1b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/2c2a71f1c77d9765c12638c4724d9ca23658a810",
-                "reference": "2c2a71f1c77d9765c12638c4724d9ca23658a810",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/59a6a299e2f5612dc8692d40e84373703a5df1b5",
+                "reference": "59a6a299e2f5612dc8692d40e84373703a5df1b5",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "symfony/console": "~2.0"
+                "symfony/console": "~2.0|~3.0"
             },
             "bin": [
                 "security-checker"
@@ -2077,7 +2134,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2096,20 +2153,20 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2015-05-28T14:22:40+00:00"
+            "time": "2017-03-29T09:29:53+00:00"
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v3.1.4",
+            "version": "v3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "4f6af7f69f29df8555a18b9bb7b646906b45924d"
+                "reference": "43590bc9614c1df5bd7b1639088f7d904842892b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/4f6af7f69f29df8555a18b9bb7b646906b45924d",
-                "reference": "4f6af7f69f29df8555a18b9bb7b646906b45924d",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/43590bc9614c1df5bd7b1639088f7d904842892b",
+                "reference": "43590bc9614c1df5bd7b1639088f7d904842892b",
                 "shasum": ""
             },
             "require": {
@@ -2123,7 +2180,7 @@
             "require-dev": {
                 "mockery/mockery": "~0.9",
                 "phpmd/phpmd": "~1.5",
-                "phpunit/phpunit": "~3.7",
+                "phpunit/phpunit": "~4",
                 "sebastian/phpcpd": "~1.4",
                 "sensiolabs/security-checker": "~1.1",
                 "squizlabs/php_codesniffer": "~1.4"
@@ -2131,7 +2188,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "v3.0.x-dev"
+                    "dev-master": "v3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2153,20 +2210,20 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2018-03-02T14:30:38+00:00"
+            "time": "2018-07-12T09:56:19+00:00"
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "3.4.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "e0afaa26ffd0a38bb89b55e95761fe9555b6670f"
+                "reference": "064c96ad28877221e1100a81477f14dbf43d0b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/e0afaa26ffd0a38bb89b55e95761fe9555b6670f",
-                "reference": "e0afaa26ffd0a38bb89b55e95761fe9555b6670f",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/064c96ad28877221e1100a81477f14dbf43d0b90",
+                "reference": "064c96ad28877221e1100a81477f14dbf43d0b90",
                 "shasum": ""
             },
             "require": {
@@ -2177,13 +2234,13 @@
                 "php": "^5.6|^7.0",
                 "sensio/framework-extra-bundle": "~3",
                 "surfnet/stepup-saml-bundle": "^4.0",
-                "symfony/config": "^2.7",
-                "symfony/dependency-injection": "^2.7",
-                "symfony/form": "^2.7",
-                "symfony/framework-bundle": "^2.7",
-                "symfony/http-kernel": "^2.7",
-                "symfony/twig-bridge": "^2.7",
-                "symfony/validator": "^2.7"
+                "symfony/config": ">=2.7,<4",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/form": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4",
+                "symfony/http-kernel": ">=2.7,<4",
+                "symfony/twig-bridge": ">=2.7,<4",
+                "symfony/validator": ">=2.7,<4"
             },
             "require-dev": {
                 "mockery/mockery": "0.9.*",
@@ -2209,20 +2266,20 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2018-04-09T11:13:53+00:00"
+            "time": "2018-08-29T11:45:58+00:00"
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
-            "version": "2.3.2",
+            "version": "2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "60cc5468d912b5ceb52d4bbf68a5b66ec109ae15"
+                "reference": "cf6515543b6a258d8d0dd76beca6b95c5cb76330"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/60cc5468d912b5ceb52d4bbf68a5b66ec109ae15",
-                "reference": "60cc5468d912b5ceb52d4bbf68a5b66ec109ae15",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/cf6515543b6a258d8d0dd76beca6b95c5cb76330",
+                "reference": "cf6515543b6a258d8d0dd76beca6b95c5cb76330",
                 "shasum": ""
             },
             "require": {
@@ -2232,11 +2289,11 @@
                 "php": "^5.6|^7.0",
                 "psr/log": "~1.0",
                 "ramsey/uuid": "^3.4",
-                "surfnet/stepup-bundle": "^3.0",
-                "symfony/config": "^2.7",
-                "symfony/dependency-injection": "^2.7",
-                "symfony/http-kernel": "^2.7",
-                "symfony/validator": "^2.7"
+                "surfnet/stepup-bundle": "^4.0",
+                "symfony/config": ">=2.7,<4",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/http-kernel": ">=2.7,<4",
+                "symfony/validator": ">=2.7,<4"
             },
             "conflict": {
                 "surfnet/stepup-middleware-client": "*"
@@ -2263,20 +2320,20 @@
                 "Apache-2.0"
             ],
             "description": "Symfony2 bundle for consuming the Step-up Middleware API.",
-            "time": "2018-03-23T14:11:33+00:00"
+            "time": "2018-08-30T11:31:21+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "4.0.0",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
-                "reference": "9bb7098248c7b60c8b2cbc74d996b027de69e68a"
+                "reference": "e6115d07eccc905fcf522552ee186f89686045cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/9bb7098248c7b60c8b2cbc74d996b027de69e68a",
-                "reference": "9bb7098248c7b60c8b2cbc74d996b027de69e68a",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/e6115d07eccc905fcf522552ee186f89686045cf",
+                "reference": "e6115d07eccc905fcf522552ee186f89686045cf",
                 "shasum": ""
             },
             "require": {
@@ -2311,7 +2368,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2018-03-21T09:35:58+00:00"
+            "time": "2018-08-29T12:18:23+00:00"
         },
         {
             "name": "surfnet/stepup-u2f-bundle",
@@ -2319,28 +2376,32 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-u2f-bundle.git",
-                "reference": "67d8400160c5c9048cdd4354303d59243edbb7bf"
+                "reference": "992f91db04afaad98f0d10645d81f4e3ea6742d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-u2f-bundle/zipball/67d8400160c5c9048cdd4354303d59243edbb7bf",
-                "reference": "67d8400160c5c9048cdd4354303d59243edbb7bf",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-u2f-bundle/zipball/992f91db04afaad98f0d10645d81f4e3ea6742d0",
+                "reference": "992f91db04afaad98f0d10645d81f4e3ea6742d0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4|^7",
-                "symfony/config": "^2.7",
-                "symfony/dependency-injection": "^2.7",
-                "symfony/form": "^2.7",
-                "symfony/http-kernel": "^2.7",
-                "symfony/validator": "^2.7",
+                "symfony/config": ">=2.7,<4",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/form": ">=2.7,<4",
+                "symfony/http-kernel": ">=2.7,<4",
+                "symfony/validator": ">=2.7,<4",
                 "yubico/u2flib-server": "^0.1.0"
             },
             "require-dev": {
-                "ibuildings/qa-tools": "~1.1,>=1.1.27",
-                "liip/rmt": "1.1.*",
-                "matthiasnoback/symfony-config-test": "^1.2",
-                "mockery/mockery": "~0.9"
+                "matthiasnoback/symfony-config-test": "^2.2",
+                "mockery/mockery": "~0.9",
+                "phpmd/phpmd": "^2.6",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/phpcpd": "^2.0",
+                "sensiolabs/security-checker": "^3.0",
+                "squizlabs/php_codesniffer": "^1.0",
+                "symfony/phpunit-bridge": "^3.0"
             },
             "type": "library",
             "autoload": {
@@ -2353,24 +2414,24 @@
                 "Apache-2.0"
             ],
             "description": "The SURFnet Step-up U2F bundle contains server-side device verification, and the necessary forms and resources to enable client-side U2F interaction with Step-up Identities",
-            "time": "2017-01-27T08:45:00+00:00"
+            "time": "2018-08-29T12:25:15+00:00"
         },
         {
             "name": "symfony/assetic-bundle",
-            "version": "v2.8.0",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/assetic-bundle.git",
-                "reference": "aa5b4f8b712f38745928fa845ddb73300bb2af6d"
+                "reference": "2e0a23a4874838e26de6f025e02fc63328921a4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/assetic-bundle/zipball/aa5b4f8b712f38745928fa845ddb73300bb2af6d",
-                "reference": "aa5b4f8b712f38745928fa845ddb73300bb2af6d",
+                "url": "https://api.github.com/repos/symfony/assetic-bundle/zipball/2e0a23a4874838e26de6f025e02fc63328921a4c",
+                "reference": "2e0a23a4874838e26de6f025e02fc63328921a4c",
                 "shasum": ""
             },
             "require": {
-                "kriswallsmith/assetic": "~1.3",
+                "kriswallsmith/assetic": "~1.4",
                 "php": ">=5.3.0",
                 "symfony/console": "~2.3|~3.0",
                 "symfony/dependency-injection": "~2.3|~3.0",
@@ -2379,7 +2440,7 @@
             },
             "conflict": {
                 "kriswallsmith/spork": "<=0.2",
-                "twig/twig": "<1.20"
+                "twig/twig": "<1.27"
             },
             "require-dev": {
                 "kriswallsmith/spork": "~0.3",
@@ -2397,7 +2458,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -2424,45 +2485,48 @@
                 "minification"
             ],
             "abandoned": "symfony/webpack-encore-pack",
-            "time": "2015-12-28T13:12:39+00:00"
+            "time": "2017-07-14T07:26:46+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "2.11.1",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "e7caf4936c7be82bc6d68df87f1d23a0d5bf6e00"
+                "reference": "2b41b8b6d2c6edb1a5494f02f8e4129be2a44784"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/e7caf4936c7be82bc6d68df87f1d23a0d5bf6e00",
-                "reference": "e7caf4936c7be82bc6d68df87f1d23a0d5bf6e00",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/2b41b8b6d2c6edb1a5494f02f8e4129be2a44784",
+                "reference": "2b41b8b6d2c6edb1a5494f02f8e4129be2a44784",
                 "shasum": ""
             },
             "require": {
-                "monolog/monolog": "~1.18",
+                "monolog/monolog": "~1.22",
                 "php": ">=5.3.2",
-                "symfony/config": "~2.3|~3.0",
-                "symfony/dependency-injection": "~2.3|~3.0",
-                "symfony/http-kernel": "~2.3|~3.0",
-                "symfony/monolog-bridge": "~2.3|~3.0"
+                "symfony/config": "~2.7|~3.0|~4.0",
+                "symfony/dependency-injection": "~2.7|~3.0|~4.0",
+                "symfony/http-kernel": "~2.7|~3.0|~4.0",
+                "symfony/monolog-bridge": "~2.7|~3.0|~4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/yaml": "~2.3|~3.0"
+                "symfony/console": "~2.3|~3.0|~4.0",
+                "symfony/phpunit-bridge": "^3.3|^4.0",
+                "symfony/yaml": "~2.3|~3.0|~4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Bundle\\MonologBundle\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2484,20 +2548,20 @@
                 "log",
                 "logging"
             ],
-            "time": "2016-04-13T16:21:01+00:00"
+            "time": "2017-11-06T16:02:17+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
-            "version": "v1.2.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "6d58bceaeea2c2d3eb62503839b18646e161cd6b"
+                "reference": "19e1b73bf255265ad0b568f81766ae2a3266d8d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/6d58bceaeea2c2d3eb62503839b18646e161cd6b",
-                "reference": "6d58bceaeea2c2d3eb62503839b18646e161cd6b",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/19e1b73bf255265ad0b568f81766ae2a3266d8d2",
+                "reference": "19e1b73bf255265ad0b568f81766ae2a3266d8d2",
                 "shasum": ""
             },
             "require": {
@@ -2506,10 +2570,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Apcu\\": ""
+                },
                 "files": [
                     "bootstrap.php"
                 ]
@@ -2537,29 +2604,32 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18T14:26:46+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2592,20 +2662,78 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "f22a90256d577c7ef7efad8df1f0201663d57644"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/f22a90256d577c7ef7efad8df1f0201663d57644",
+                "reference": "f22a90256d577c7ef7efad8df1f0201663d57644",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/intl": "~2.3|~3.0|~4.0"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -2617,7 +2745,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2651,39 +2779,222 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18T14:26:46+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
-            "name": "symfony/symfony",
-            "version": "v2.7.49",
+            "name": "symfony/polyfill-php56",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/symfony.git",
-                "reference": "3425d87198b43400e95b829ae1ce7b3a86976f51"
+                "url": "https://github.com/symfony/polyfill-php56.git",
+                "reference": "7b4fc009172cc0196535b0328bd1226284a28000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/3425d87198b43400e95b829ae1ce7b3a86976f51",
-                "reference": "3425d87198b43400e95b829ae1ce7b3a86976f51",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/7b4fc009172cc0196535b0328bd1226284a28000",
+                "reference": "7b4fc009172cc0196535b0328bd1226284a28000",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-util": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php56\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
+                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0|~9.99",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-util",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-util.git",
+                "reference": "8e15d04ba3440984d23e7964b2ee1d25c8de1581"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/8e15d04ba3440984d23e7964b2ee1d25c8de1581",
+                "reference": "8e15d04ba3440984d23e7964b2ee1d25c8de1581",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Util\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony utilities for portability of PHP codes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compat",
+                "compatibility",
+                "polyfill",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/symfony",
+            "version": "v3.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/symfony.git",
+                "reference": "5bb5c2d4b0d5cf10672015b68519a199e6ac27c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/5bb5c2d4b0d5cf10672015b68519a199e6ac27c1",
+                "reference": "5bb5c2d4b0d5cf10672015b68519a199e6ac27c1",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "~2.4",
                 "ext-xml": "*",
-                "paragonie/random_compat": "~1.0",
-                "php": ">=5.3.9",
+                "fig/link-util": "^1.0",
+                "php": "^5.5.9|>=7.0.8",
+                "psr/cache": "~1.0",
+                "psr/container": "^1.0",
+                "psr/link": "^1.0",
                 "psr/log": "~1.0",
+                "psr/simple-cache": "^1.0",
                 "symfony/polyfill-apcu": "~1.1",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.1",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php56": "~1.0",
+                "symfony/polyfill-php70": "~1.6",
+                "twig/twig": "^1.35|^2.4.4"
             },
             "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/container-implementation": "1.0",
+                "psr/log-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
             },
             "replace": {
                 "symfony/asset": "self.version",
                 "symfony/browser-kit": "self.version",
+                "symfony/cache": "self.version",
                 "symfony/class-loader": "self.version",
                 "symfony/config": "self.version",
                 "symfony/console": "self.version",
@@ -2693,6 +3004,7 @@
                 "symfony/dependency-injection": "self.version",
                 "symfony/doctrine-bridge": "self.version",
                 "symfony/dom-crawler": "self.version",
+                "symfony/dotenv": "self.version",
                 "symfony/event-dispatcher": "self.version",
                 "symfony/expression-language": "self.version",
                 "symfony/filesystem": "self.version",
@@ -2701,49 +3013,57 @@
                 "symfony/framework-bundle": "self.version",
                 "symfony/http-foundation": "self.version",
                 "symfony/http-kernel": "self.version",
+                "symfony/inflector": "self.version",
                 "symfony/intl": "self.version",
-                "symfony/locale": "self.version",
+                "symfony/ldap": "self.version",
+                "symfony/lock": "self.version",
                 "symfony/monolog-bridge": "self.version",
                 "symfony/options-resolver": "self.version",
                 "symfony/process": "self.version",
                 "symfony/property-access": "self.version",
+                "symfony/property-info": "self.version",
                 "symfony/proxy-manager-bridge": "self.version",
                 "symfony/routing": "self.version",
                 "symfony/security": "self.version",
-                "symfony/security-acl": "self.version",
                 "symfony/security-bundle": "self.version",
                 "symfony/security-core": "self.version",
                 "symfony/security-csrf": "self.version",
+                "symfony/security-guard": "self.version",
                 "symfony/security-http": "self.version",
                 "symfony/serializer": "self.version",
                 "symfony/stopwatch": "self.version",
-                "symfony/swiftmailer-bridge": "self.version",
                 "symfony/templating": "self.version",
                 "symfony/translation": "self.version",
                 "symfony/twig-bridge": "self.version",
                 "symfony/twig-bundle": "self.version",
                 "symfony/validator": "self.version",
                 "symfony/var-dumper": "self.version",
+                "symfony/web-link": "self.version",
                 "symfony/web-profiler-bundle": "self.version",
+                "symfony/web-server-bundle": "self.version",
+                "symfony/workflow": "self.version",
                 "symfony/yaml": "self.version"
             },
             "require-dev": {
+                "cache/integration-tests": "dev-master",
                 "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.6",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
-                "doctrine/doctrine-bundle": "~1.2",
+                "doctrine/doctrine-bundle": "~1.4",
                 "doctrine/orm": "~2.4,>=2.4.5",
-                "egulias/email-validator": "~1.2,>=1.2.1",
-                "ircmaxell/password-compat": "~1.0",
+                "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-                "sensio/framework-extra-bundle": "^3.0.2",
-                "symfony/phpunit-bridge": "~3.4|~4.0"
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "predis/predis": "~1.0",
+                "symfony/phpunit-bridge": "~3.4|~4.0",
+                "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -2751,17 +3071,12 @@
                     "Symfony\\Bridge\\Doctrine\\": "src/Symfony/Bridge/Doctrine/",
                     "Symfony\\Bridge\\Monolog\\": "src/Symfony/Bridge/Monolog/",
                     "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
-                    "Symfony\\Bridge\\Swiftmailer\\": "src/Symfony/Bridge/Swiftmailer/",
                     "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
                     "Symfony\\Bundle\\": "src/Symfony/Bundle/",
                     "Symfony\\Component\\": "src/Symfony/Component/"
                 },
                 "classmap": [
-                    "src/Symfony/Component/HttpFoundation/Resources/stubs",
                     "src/Symfony/Component/Intl/Resources/stubs"
-                ],
-                "files": [
-                    "src/Symfony/Component/Intl/Resources/stubs/functions.php"
                 ],
                 "exclude-from-classmap": [
                     "**/Tests/"
@@ -2786,20 +3101,20 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2018-08-01T13:57:05+00:00"
+            "time": "2018-08-28T06:06:28+00:00"
         },
         {
             "name": "twbs/bootstrap",
-            "version": "v3.2.0",
+            "version": "v3.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twbs/bootstrap.git",
-                "reference": "c068162161154a4b85110ea1e7dd3d7897ce2b72"
+                "reference": "0b9c4a4007c44201dce9a6cc1a38407005c26c86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twbs/bootstrap/zipball/c068162161154a4b85110ea1e7dd3d7897ce2b72",
-                "reference": "c068162161154a4b85110ea1e7dd3d7897ce2b72",
+                "url": "https://api.github.com/repos/twbs/bootstrap/zipball/0b9c4a4007c44201dce9a6cc1a38407005c26c86",
+                "reference": "0b9c4a4007c44201dce9a6cc1a38407005c26c86",
                 "shasum": ""
             },
             "replace": {
@@ -2808,7 +3123,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "3.3.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2837,27 +3152,28 @@
                 "responsive",
                 "web"
             ],
-            "time": "2014-06-26T16:36:48+00:00"
+            "time": "2016-07-25T15:51:55+00:00"
         },
         {
             "name": "twig/extensions",
-            "version": "v1.3.0",
+            "version": "v1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig-extensions.git",
-                "reference": "449e3c8a9ffad7c2479c7864557275a32b037499"
+                "reference": "2c1a86526d0044065220d1b51ac08348bea5ca82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/449e3c8a9ffad7c2479c7864557275a32b037499",
-                "reference": "449e3c8a9ffad7c2479c7864557275a32b037499",
+                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/2c1a86526d0044065220d1b51ac08348bea5ca82",
+                "reference": "2c1a86526d0044065220d1b51ac08348bea5ca82",
                 "shasum": ""
             },
             "require": {
-                "twig/twig": "~1.20|~2.0"
+                "twig/twig": "^1.27|^2.0"
             },
             "require-dev": {
-                "symfony/translation": "~2.3"
+                "symfony/phpunit-bridge": "^3.4",
+                "symfony/translation": "^2.7|^3.4"
             },
             "suggest": {
                 "symfony/translation": "Allow the time_diff output to be translated"
@@ -2865,12 +3181,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Twig_Extensions_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\Extensions\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2884,12 +3203,11 @@
                 }
             ],
             "description": "Common additional features for Twig that do not directly belong in core",
-            "homepage": "http://twig.sensiolabs.org/doc/extensions/index.html",
             "keywords": [
                 "i18n",
                 "text"
             ],
-            "time": "2015-08-22T16:38:35+00:00"
+            "time": "2018-05-22T13:26:07+00:00"
         },
         {
             "name": "twig/twig",
@@ -2959,16 +3277,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -3005,7 +3323,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "yubico/u2flib-server",
@@ -3095,74 +3413,21 @@
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "guzzlehttp/streams",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "f91b721d73f0e561410903b3b3c90a5d0e40b534"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/f91b721d73f0e561410903b3b3c90a5d0e40b534",
-                "reference": "f91b721d73f0e561410903b3b3c90a5d0e40b534",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data (Guzzle 4+)",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "time": "2014-08-17T21:15:53+00:00"
-        },
-        {
             "name": "hamcrest/hamcrest-php",
-            "version": "v1.2.2",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^5.3|^7.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -3171,15 +3436,18 @@
             },
             "require-dev": {
                 "phpunit/php-file-iterator": "1.3.3",
-                "satooshi/php-coveralls": "dev-master"
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "hamcrest"
-                ],
-                "files": [
-                    "hamcrest/Hamcrest.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3190,29 +3458,29 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11T14:41:42+00:00"
+            "time": "2016-01-20T08:20:44+00:00"
         },
         {
             "name": "matthiasnoback/symfony-config-test",
-            "version": "v1.4.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SymfonyTest/SymfonyConfigTest.git",
-                "reference": "615b7c8ff5dc1737e553e518dbed641aa548572d"
+                "reference": "8d48332ed83ac3bacc99ce487ade25df2613ab1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SymfonyTest/SymfonyConfigTest/zipball/615b7c8ff5dc1737e553e518dbed641aa548572d",
-                "reference": "615b7c8ff5dc1737e553e518dbed641aa548572d",
+                "url": "https://api.github.com/repos/SymfonyTest/SymfonyConfigTest/zipball/8d48332ed83ac3bacc99ce487ade25df2613ab1e",
+                "reference": "8d48332ed83ac3bacc99ce487ade25df2613ab1e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "sebastian/exporter": "1.*",
-                "symfony/config": "~2.0|~3.0"
+                "php": "^5.3|^7.0",
+                "sebastian/exporter": "^1.0|^2.0",
+                "symfony/config": "^2.3|^3.0|^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=3.7"
+                "phpunit/phpunit": "^4.0|^5.0"
             },
             "type": "library",
             "autoload": {
@@ -3238,34 +3506,35 @@
                 "phpunit",
                 "symfony"
             ],
-            "time": "2015-11-25T21:40:32+00:00"
+            "time": "2017-11-21T18:42:45+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2"
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/4db079511a283e5aba1b3c2fb19037c645e70fc2",
-                "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/99e29d3596b16dabe4982548527d5ddf90232e99",
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99",
                 "shasum": ""
             },
             "require": {
-                "hamcrest/hamcrest-php": "~1.1",
+                "hamcrest/hamcrest-php": "~2.0",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.3.2"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpdocumentor/phpdocumentor": "^2.9",
+                "phpunit/phpunit": "~5.7.10|~6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -3289,8 +3558,8 @@
                     "homepage": "http://davedevelopment.co.uk"
                 }
             ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-            "homepage": "http://github.com/padraic/mockery",
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
             "keywords": [
                 "BDD",
                 "TDD",
@@ -3303,30 +3572,75 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-05-22T21:52:33+00:00"
+            "time": "2018-05-08T08:54:48+00:00"
         },
         {
-            "name": "pdepend/pdepend",
-            "version": "2.5.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "0c50874333149c0dad5a2877801aed148f2767ff"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/0c50874333149c0dad5a2877801aed148f2767ff",
-                "reference": "0c50874333149c0dad5a2877801aed148f2767ff",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "pdepend/pdepend",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "9daf26d0368d4a12bed1cacae1a9f3a6f0adf239"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/9daf26d0368d4a12bed1cacae1a9f3a6f0adf239",
+                "reference": "9daf26d0368d4a12bed1cacae1a9f3a6f0adf239",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3",
-                "symfony/dependency-injection": "^2.3.0|^3",
-                "symfony/filesystem": "^2.3.0|^3"
+                "symfony/config": "^2.3.0|^3|^4",
+                "symfony/dependency-injection": "^2.3.0|^3|^4",
+                "symfony/filesystem": "^2.3.0|^3|^4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.4.0,<4.8",
+                "phpunit/phpunit": "^4.8|^5.7",
                 "squizlabs/php_codesniffer": "^2.0.0"
             },
             "bin": [
@@ -3343,20 +3657,20 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-01-19T14:23:36+00:00"
+            "time": "2017-12-13T13:21:38+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -3397,26 +3711,26 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -3442,24 +3756,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -3489,7 +3803,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -3559,33 +3873,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -3618,43 +3932,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -3680,20 +3995,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -3727,7 +4042,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3821,16 +4136,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "1.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
                 "shasum": ""
             },
             "require": {
@@ -3866,44 +4181,54 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.35",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -3912,7 +4237,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -3938,30 +4263,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06T05:18:07+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -3969,7 +4297,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -3994,7 +4322,52 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -4062,23 +4435,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -4110,32 +4483,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -4160,25 +4533,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -4187,7 +4560,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -4227,24 +4600,24 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/finder-facade",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/finder-facade.git",
-                "reference": "2a6f7f57efc0aa2d23297d9fd9e2a03111a8c0b9"
+                "reference": "4a3174709c2dc565fe5fb26fcf827f6a1fc7b09f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/finder-facade/zipball/2a6f7f57efc0aa2d23297d9fd9e2a03111a8c0b9",
-                "reference": "2a6f7f57efc0aa2d23297d9fd9e2a03111a8c0b9",
+                "url": "https://api.github.com/repos/sebastianbergmann/finder-facade/zipball/4a3174709c2dc565fe5fb26fcf827f6a1fc7b09f",
+                "reference": "4a3174709c2dc565fe5fb26fcf827f6a1fc7b09f",
                 "shasum": ""
             },
             "require": {
-                "symfony/finder": "~2.3|~3.0",
+                "symfony/finder": "~2.3|~3.0|~4.0",
                 "theseer/fdomdocument": "~1.3"
             },
             "type": "library",
@@ -4266,7 +4639,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
-            "time": "2016-02-17T07:02:23+00:00"
+            "time": "2017-11-18T17:31:49+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -4318,6 +4691,52 @@
                 "global state"
             ],
             "time": "2015-10-12T03:26:01+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/phpcpd",
@@ -4372,16 +4791,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -4393,7 +4812,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -4421,23 +4840,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11T19:50:13+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -4456,55 +4925,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
-        },
-        {
-            "name": "sensio/generator-bundle",
-            "version": "v2.5.3",
-            "target-dir": "Sensio/Bundle/GeneratorBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "e50108c2133ee5c9c484555faed50c17a61221d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/e50108c2133ee5c9c484555faed50c17a61221d3",
-                "reference": "e50108c2133ee5c9c484555faed50c17a61221d3",
-                "shasum": ""
-            },
-            "require": {
-                "symfony/console": "~2.5",
-                "symfony/framework-bundle": "~2.2"
-            },
-            "require-dev": {
-                "doctrine/orm": "~2.2,>=2.2.3",
-                "symfony/doctrine-bridge": "~2.2",
-                "twig/twig": "~1.11"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Sensio\\Bundle\\GeneratorBundle": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "This bundle generates code for you",
-            "time": "2015-03-17T06:36:52+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4582,17 +5003,83 @@
             "time": "2014-12-04T22:32:15+00:00"
         },
         {
-            "name": "theseer/fdomdocument",
-            "version": "1.6.1",
+            "name": "symfony/phpunit-bridge",
+            "version": "v3.4.15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/fDOMDocument.git",
-                "reference": "d9ad139d6c2e8edf5e313ffbe37ff13344cf0684"
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "f4fde1ede82c7ca2a4f06cf48521a185b26c0fed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/fDOMDocument/zipball/d9ad139d6c2e8edf5e313ffbe37ff13344cf0684",
-                "reference": "d9ad139d6c2e8edf5e313ffbe37ff13344cf0684",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/f4fde1ede82c7ca2a4f06cf48521a185b26c0fed",
+                "reference": "f4fde1ede82c7ca2a4f06cf48521a185b26c0fed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "ext-zip": "Zip support is required when using bin/simple-phpunit",
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2018-08-27T15:17:06+00:00"
+        },
+        {
+            "name": "theseer/fdomdocument",
+            "version": "1.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/fDOMDocument.git",
+                "reference": "6e8203e40a32a9c770bcb62fe37e68b948da6dca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/fDOMDocument/zipball/6e8203e40a32a9c770bcb62fe37e68b948da6dca",
+                "reference": "6e8203e40a32a9c770bcb62fe37e68b948da6dca",
                 "shasum": ""
             },
             "require": {
@@ -4619,14 +5106,14 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
-            "time": "2015-05-27T22:58:02+00:00"
+            "time": "2017-06-30T11:53:12+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "mopa/bootstrap-bundle": 5,
-        "surfnet/stepup-u2f-bundle": 20
+        "surfnet/stepup-u2f-bundle": 20,
+        "ee/dataexporter-bundle": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Surfnet/StepupRa/RaBundle/Controller/LocaleController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/LocaleController.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupRa\RaBundle\Controller;
 
 use Psr\Log\LoggerInterface;
 use Surfnet\StepupBundle\Command\SwitchLocaleCommand;
+use Surfnet\StepupBundle\Form\Type\SwitchLocaleType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -56,13 +57,13 @@ final class LocaleController extends Controller
         $command->identityId = $identity->id;
 
         $form = $this->createForm(
-            'stepup_switch_locale',
+            SwitchLocaleType::class,
             $command,
             ['route' => 'ra_switch_locale', 'route_parameters' => ['return_url' => $returnUrl]]
         );
         $form->handleRequest($request);
 
-        if (!$form->isValid()) {
+        if ($form->isSubmitted() && !$form->isValid()) {
             $this->addFlash('error', $this->get('translator')->trans('ra.flash.invalid_switch_locale_form'));
             $logger->error('The switch locale form unexpectedly contained invalid data');
             return $this->redirect($returnUrl);

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php
@@ -86,7 +86,7 @@ final class RaLocationController extends Controller
 
         $form = $this->createForm(CreateRaLocationType::class, $command)->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $logger->debug('RA Location form submitted, start processing command');
 
             $success = $this->getRaLocationService()->create($command);
@@ -147,7 +147,7 @@ final class RaLocationController extends Controller
 
         $form = $this->createForm(ChangeRaLocationType::class, $command)->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $logger->debug('RA Location form submitted, start processing command');
 
             $success = $this->getRaLocationService()->change($command);

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php
@@ -23,12 +23,19 @@ use Surfnet\StepupRa\RaBundle\Command\ChangeRaLocationCommand;
 use Surfnet\StepupRa\RaBundle\Command\CreateRaLocationCommand;
 use Surfnet\StepupRa\RaBundle\Command\RemoveRaLocationCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaLocationsCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\ChangeRaLocationType;
+use Surfnet\StepupRa\RaBundle\Form\Type\CreateRaLocationType;
+use Surfnet\StepupRa\RaBundle\Form\Type\RemoveRaLocationType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) By making the Form Type classes explicit, MD now realizes couping
+ *                                                 is to high.
+ */
 final class RaLocationController extends Controller
 {
     /**
@@ -50,7 +57,7 @@ final class RaLocationController extends Controller
 
         $locations = $this->getRaLocationService()->search($command);
 
-        $removalForm = $this->createForm('ra_remove_ra_location', new RemoveRaLocationCommand());
+        $removalForm = $this->createForm(RemoveRaLocationType::class, new RemoveRaLocationCommand());
 
         $this->get('logger')->notice(sprintf(
             'Searching for RA locations yielded "%d" results',
@@ -77,7 +84,7 @@ final class RaLocationController extends Controller
         $command->institution = $identity->institution;
         $command->currentUserId = $identity->id;
 
-        $form = $this->createForm('ra_create_ra_location', $command)->handleRequest($request);
+        $form = $this->createForm(CreateRaLocationType::class, $command)->handleRequest($request);
 
         if ($form->isValid()) {
             $logger->debug('RA Location form submitted, start processing command');
@@ -138,7 +145,7 @@ final class RaLocationController extends Controller
         $command->location = $raLocation->location;
         $command->contactInformation = $raLocation->contactInformation;
 
-        $form = $this->createForm('ra_change_ra_location', $command)->handleRequest($request);
+        $form = $this->createForm(ChangeRaLocationType::class, $command)->handleRequest($request);
 
         if ($form->isValid()) {
             $logger->debug('RA Location form submitted, start processing command');
@@ -179,7 +186,7 @@ final class RaLocationController extends Controller
         $command = new RemoveRaLocationCommand();
         $command->currentUserId = $this->getCurrentUser()->id;
 
-        $form = $this->createForm('ra_remove_ra_location', $command);
+        $form = $this->createForm(RemoveRaLocationType::class, $command);
         $form->handleRequest($request);
 
         $logger->info(sprintf(

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -26,6 +26,7 @@ use Surfnet\StepupRa\RaBundle\Command\RetractRegistrationAuthorityCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaCandidatesCommand;
 use Surfnet\StepupRa\RaBundle\Form\Type\AmendRegistrationAuthorityInformationType;
 use Surfnet\StepupRa\RaBundle\Form\Type\ChangeRaRoleType;
+use Surfnet\StepupRa\RaBundle\Form\Type\CreateRaType;
 use Surfnet\StepupRa\RaBundle\Form\Type\RetractRegistrationAuthorityType;
 use Surfnet\StepupRa\RaBundle\Form\Type\SearchRaCandidatesType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -24,6 +24,10 @@ use Surfnet\StepupRa\RaBundle\Command\AmendRegistrationAuthorityInformationComma
 use Surfnet\StepupRa\RaBundle\Command\ChangeRaRoleCommand;
 use Surfnet\StepupRa\RaBundle\Command\RetractRegistrationAuthorityCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaCandidatesCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\AmendRegistrationAuthorityInformationType;
+use Surfnet\StepupRa\RaBundle\Form\Type\ChangeRaRoleType;
+use Surfnet\StepupRa\RaBundle\Form\Type\RetractRegistrationAuthorityType;
+use Surfnet\StepupRa\RaBundle\Form\Type\SearchRaCandidatesType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
@@ -97,7 +101,7 @@ class RaManagementController extends Controller
         $command->orderBy        = $request->get('orderBy');
         $command->orderDirection = $request->get('orderDirection');
 
-        $form = $this->createForm('ra_search_ra_candidates', $command, ['method' => 'get']);
+        $form = $this->createForm(SearchRaCandidatesType::class, $command, ['method' => 'get']);
         $form->handleRequest($request);
 
         $service = $this->getRaCandidateService();
@@ -159,7 +163,7 @@ class RaManagementController extends Controller
         $command->identityId  = $identityId;
         $command->institution = $raCandidate->institution;
 
-        $form = $this->createForm('ra_management_create_ra', $command)->handleRequest($request);
+        $form = $this->createForm(CreateRaType::class, $command)->handleRequest($request);
         if ($form->isValid()) {
             $logger->debug('Accreditation form submitted, start processing command');
 
@@ -209,7 +213,7 @@ class RaManagementController extends Controller
         $command->location = $raListing->location;
         $command->contactInformation = $raListing->contactInformation;
 
-        $form = $this->createForm('ra_management_amend_ra_info', $command)->handleRequest($request);
+        $form = $this->createForm(AmendRegistrationAuthorityInformationType::class, $command)->handleRequest($request);
         if ($form->isValid()) {
             $logger->notice(sprintf("RA(A) '%s' information amendment form submitted, processing", $identityId));
 
@@ -253,7 +257,7 @@ class RaManagementController extends Controller
         $command->institution = $raListing->institution;
         $command->role        = $raListing->role;
 
-        $form = $this->createForm('ra_management_change_ra_role', $command)->handleRequest($request);
+        $form = $this->createForm(ChangeRaRoleType::class, $command)->handleRequest($request);
         if ($form->isValid()) {
             $logger->notice(sprintf('RA(A) "%s" Change Role form submitted, processing', $identityId));
 
@@ -295,7 +299,7 @@ class RaManagementController extends Controller
         $command = new RetractRegistrationAuthorityCommand();
         $command->identityId = $identityId;
 
-        $form = $this->createForm('ra_management_retract_registration_authority', $command)->handleRequest($request);
+        $form = $this->createForm(RetractRegistrationAuthorityType::class, $command)->handleRequest($request);
         if ($form->isValid()) {
             if ($form->get('cancel')->isClicked()) {
                 $logger->notice('Retraction of registration authority cancelled');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -164,7 +164,7 @@ class RaManagementController extends Controller
         $command->institution = $raCandidate->institution;
 
         $form = $this->createForm(CreateRaType::class, $command)->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $logger->debug('Accreditation form submitted, start processing command');
 
             $success = $this->getRaCandidateService()->accreditCandidate($command);
@@ -214,7 +214,7 @@ class RaManagementController extends Controller
         $command->contactInformation = $raListing->contactInformation;
 
         $form = $this->createForm(AmendRegistrationAuthorityInformationType::class, $command)->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $logger->notice(sprintf("RA(A) '%s' information amendment form submitted, processing", $identityId));
 
             if ($this->get('ra.service.ra')->amendRegistrationAuthorityInformation($command)) {
@@ -258,7 +258,7 @@ class RaManagementController extends Controller
         $command->role        = $raListing->role;
 
         $form = $this->createForm(ChangeRaRoleType::class, $command)->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $logger->notice(sprintf('RA(A) "%s" Change Role form submitted, processing', $identityId));
 
             if ($this->get('ra.service.ra')->changeRegistrationAuthorityRole($command)) {
@@ -300,7 +300,7 @@ class RaManagementController extends Controller
         $command->identityId = $identityId;
 
         $form = $this->createForm(RetractRegistrationAuthorityType::class, $command)->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             if ($form->get('cancel')->isClicked()) {
                 $logger->notice('Retraction of registration authority cancelled');
                 return $this->redirectToRoute('ra_management_manage');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php
@@ -23,11 +23,17 @@ use Surfnet\StepupRa\RaBundle\Command\ExportRaSecondFactorsCommand;
 use Surfnet\StepupRa\RaBundle\Command\RevokeSecondFactorCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaSecondFactorsCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchSecondFactorAuditLogCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\RevokeSecondFactorType;
+use Surfnet\StepupRa\RaBundle\Form\Type\SearchRaSecondFactorsType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) By making the Form Type classes explicit, MD now realizes couping
+ *                                                 is to high.
+ */
 final class SecondFactorController extends Controller
 {
     /**
@@ -48,7 +54,7 @@ final class SecondFactorController extends Controller
         $command->orderBy = $request->get('orderBy');
         $command->orderDirection = $request->get('orderDirection');
 
-        $form = $this->createForm('ra_search_ra_second_factors', $command, ['method' => 'get']);
+        $form = $this->createForm(SearchRaSecondFactorsType::class, $command, ['method' => 'get']);
         $form->handleRequest($request);
 
         $secondFactors = $this->getSecondFactorService()->search($command);
@@ -65,7 +71,7 @@ final class SecondFactorController extends Controller
             $secondFactors->getItemsPerPage()
         );
 
-        $revocationForm = $this->createForm('ra_revoke_second_factor', new RevokeSecondFactorCommand());
+        $revocationForm = $this->createForm(RevokeSecondFactorType::class, new RevokeSecondFactorCommand());
 
         $this->get('logger')->notice(sprintf(
             'Searching for second factors yielded "%d" results',
@@ -111,7 +117,7 @@ final class SecondFactorController extends Controller
         $command = new RevokeSecondFactorCommand();
         $command->currentUserId = $this->getCurrentUser()->id;
 
-        $form = $this->createForm('ra_revoke_second_factor', $command);
+        $form = $this->createForm(RevokeSecondFactorType::class, $command);
         $form->handleRequest($request);
 
         $logger->info(sprintf(

--- a/src/Surfnet/StepupRa/RaBundle/Controller/SraaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/SraaController.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupRa\RaBundle\Controller;
 
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
 use Surfnet\StepupRa\RaBundle\Command\SelectInstitutionCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\InstitutionSelectionType;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,7 +43,7 @@ class SraaController extends Controller
         $command = new SelectInstitutionCommand();
         $command->institution = $identity->institution;
 
-        $form = $this->createForm('sraa_institution_select', $command);
+        $form = $this->createForm(InstitutionSelectionType::class, $command);
         $form->handleRequest($request);
 
         if ($form->isValid()) {

--- a/src/Surfnet/StepupRa/RaBundle/Controller/SraaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/SraaController.php
@@ -46,7 +46,7 @@ class SraaController extends Controller
         $form = $this->createForm(InstitutionSelectionType::class, $command);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $institutionConfigurationOptions = $this->get('ra.service.institution_configuration_options')
                 ->getInstitutionConfigurationOptionsFor($command->institution);
             $token->changeInstitutionScope($command->institution, $institutionConfigurationOptions);

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/GssfController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/GssfController.php
@@ -24,8 +24,8 @@ use Surfnet\SamlBundle\Http\XMLResponse;
 use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
 use Surfnet\SamlBundle\SAML2\Response\Assertion\InResponseTo;
 use Surfnet\StepupRa\RaBundle\Exception\RuntimeException;
+use Surfnet\StepupRa\RaBundle\Form\Type\InitiateGssfType;
 use Surfnet\StepupRa\RaBundle\Service\VettingService;
-use Surfnet\StepupRa\SamlStepupProviderBundle\Provider\ViewConfig;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -258,7 +258,7 @@ final class GssfController extends SecondFactorController
         $secondFactorConfig = $collection->getByIdentifier($provider);
 
         $form = $this->createForm(
-            'ra_initiate_gssf',
+            InitiateGssfType::class,
             null,
             [
                 'procedureId' => $procedureId,

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/SmsController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/SmsController.php
@@ -23,6 +23,8 @@ use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupBundle\Command\VerifyPhoneNumberCommand;
 use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
+use Surfnet\StepupRa\RaBundle\Form\Type\SendSmsChallengeType;
+use Surfnet\StepupRa\RaBundle\Form\Type\VerifyPhoneNumberType;
 use Surfnet\StepupRa\RaBundle\Service\VettingService;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\SubmitButton;
@@ -53,7 +55,7 @@ class SmsController extends SecondFactorController
         }
 
         $command = new SendSmsChallengeCommand();
-        $form = $this->createForm('ra_send_sms_challenge', $command)->handleRequest($request);
+        $form = $this->createForm(SendSmsChallengeType::class, $command)->handleRequest($request);
 
         $vettingService = $this->getVettingService();
         $phoneNumber = InternationalPhoneNumber::fromStringFormat(
@@ -110,7 +112,7 @@ class SmsController extends SecondFactorController
 
         $command = new VerifyPossessionOfPhoneCommand();
         $form = $this
-            ->createForm('ra_verify_phone_number', $command, ['procedureId' => $procedureId])
+            ->createForm(VerifyPhoneNumberType::class, $command, ['procedureId' => $procedureId])
             ->handleRequest($request);
 
         /** @var SubmitButton $cancelButton */

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/SmsController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/SmsController.php
@@ -66,7 +66,7 @@ class SmsController extends SecondFactorController
         $maximumOtpRequests = $vettingService->getSmsMaximumOtpRequestsCount();
         $viewVariables = ['otpRequestsRemaining' => $otpRequestsRemaining, 'maximumOtpRequests' => $maximumOtpRequests];
 
-        if (!$form->isValid()) {
+        if (!$form->isSubmitted() || !$form->isValid()) {
             $logger->notice('Form has not been submitted, not sending SMS, rendering Send SMS Challenge page');
 
             return array_merge(
@@ -124,7 +124,7 @@ class SmsController extends SecondFactorController
             return $this->redirectToRoute('ra_vetting_search');
         }
 
-        if (!$form->isValid()) {
+        if (!$form->isSubmitted() || !$form->isValid()) {
             $logger->notice(
                 'SMS OTP was not submitted through form, rendering Proof of Possession of SMS Second Factor page'
             );

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/U2fController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/U2fController.php
@@ -21,8 +21,8 @@ namespace Surfnet\StepupRa\RaBundle\Controller\Vetting;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\StepupRa\RaBundle\Command\VerifyU2fPublicIdCommand;
 use Surfnet\StepupRa\RaBundle\Service\VettingService;
-use Surfnet\StepupU2fBundle\Dto\RegisterResponse;
 use Surfnet\StepupU2fBundle\Dto\SignResponse;
+use Surfnet\StepupU2fBundle\Form\Type\VerifyDeviceAuthenticationType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -88,7 +88,7 @@ class U2fController extends SecondFactorController
 
         $formAction = $this->generateUrl('ra_vetting_u2f_prove_possession', ['procedureId' => $procedureId]);
         $form = $this->createForm(
-            'surfnet_stepup_u2f_verify_device_authentication',
+            VerifyDeviceAuthenticationType::class,
             $signResponse,
             ['sign_request' => $signRequest, 'action' => $formAction,]
         );
@@ -114,7 +114,7 @@ class U2fController extends SecondFactorController
         $formAction = $this->generateUrl('ra_vetting_u2f_prove_possession', ['procedureId' => $procedureId]);
         $form = $this
             ->createForm(
-                'surfnet_stepup_u2f_verify_device_authentication',
+                VerifyDeviceAuthenticationType::class,
                 $signResponse,
                 ['sign_request' => $signRequest, 'action' => $formAction]
             )

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/U2fController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/U2fController.php
@@ -120,7 +120,7 @@ class U2fController extends SecondFactorController
             )
             ->handleRequest($request);
 
-        if (!$form->isValid()) {
+        if (!$form->isSubmitted() || !$form->isValid()) {
             return $this->render('SurfnetStepupRaRaBundle:Vetting/U2f:authentication.html.twig', [
                 'authenticationFailed' => true,
                 'procedureId' => $procedureId,

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupRa\RaBundle\Controller\Vetting;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Surfnet\StepupRa\RaBundle\Command\VerifyYubikeyPublicIdCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\VerifyYubikeyPublicIdType;
 use Surfnet\StepupRa\RaBundle\Service\VettingService;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,7 +50,7 @@ class YubikeyController extends SecondFactorController
         }
 
         $command = new VerifyYubikeyPublicIdCommand();
-        $form = $this->createForm('ra_verify_yubikey_public_id', $command)->handleRequest($request);
+        $form = $this->createForm(VerifyYubikeyPublicIdType::class, $command)->handleRequest($request);
 
         if ($form->isValid()) {
             $result = $this->getVettingService()->verifyYubikeyPublicId($procedureId, $command);

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
@@ -52,7 +52,7 @@ class YubikeyController extends SecondFactorController
         $command = new VerifyYubikeyPublicIdCommand();
         $form = $this->createForm(VerifyYubikeyPublicIdType::class, $command)->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $result = $this->getVettingService()->verifyYubikeyPublicId($procedureId, $command);
 
             if ($result->didPublicIdMatch()) {

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -26,6 +26,7 @@ use Surfnet\StepupRa\RaBundle\Command\VerifyIdentityCommand;
 use Surfnet\StepupRa\RaBundle\Exception\DomainException;
 use Surfnet\StepupRa\RaBundle\Exception\RuntimeException;
 use Surfnet\StepupRa\RaBundle\Form\Type\StartVettingProcedureType;
+use Surfnet\StepupRa\RaBundle\Form\Type\VerifyIdentityType;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Service\SecondFactorService;
 use Surfnet\StepupRa\RaBundle\Service\VettingService;
@@ -202,7 +203,7 @@ class VettingController extends Controller
         }
 
         $command = new VerifyIdentityCommand();
-        $form = $this->createForm('ra_verify_identity', $command)->handleRequest($request);
+        $form = $this->createForm(VerifyIdentityType::class, $command)->handleRequest($request);
 
         /** @var SubmitButton $cancelButton */
         $cancelButton = $form->get('cancel');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -25,6 +25,7 @@ use Surfnet\StepupRa\RaBundle\Command\StartVettingProcedureCommand;
 use Surfnet\StepupRa\RaBundle\Command\VerifyIdentityCommand;
 use Surfnet\StepupRa\RaBundle\Exception\DomainException;
 use Surfnet\StepupRa\RaBundle\Exception\RuntimeException;
+use Surfnet\StepupRa\RaBundle\Form\Type\StartVettingProcedureType;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Service\SecondFactorService;
 use Surfnet\StepupRa\RaBundle\Service\VettingService;
@@ -59,7 +60,7 @@ class VettingController extends Controller
 
         $command = new StartVettingProcedureCommand();
 
-        $form = $this->createForm('ra_start_vetting_procedure', $command)->handleRequest($request);
+        $form = $this->createForm(StartVettingProcedureType::class, $command)->handleRequest($request);
 
         if (!$form->isValid()) {
             $logger->notice('No search submitted, displaying search by registration code form');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -63,7 +63,7 @@ class VettingController extends Controller
 
         $form = $this->createForm(StartVettingProcedureType::class, $command)->handleRequest($request);
 
-        if (!$form->isValid()) {
+        if (!$form->isSubmitted() || !$form->isValid()) {
             $logger->notice('No search submitted, displaying search by registration code form');
 
             return ['form' => $form->createView()];
@@ -189,6 +189,9 @@ class VettingController extends Controller
      * @param Request $request
      * @param string $procedureId
      * @return array|Response
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function verifyIdentityAction(Request $request, $procedureId)
     {
@@ -225,7 +228,7 @@ class VettingController extends Controller
             return ['commonName' => $commonName, 'form' => $form->createView()];
         };
 
-        if (!$form->isValid()) {
+        if (!$form->isSubmitted() || !$form->isValid()) {
             $logger->notice('Verify Identity Form not submitted, displaying form');
 
             return $showForm();

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/AmendRegistrationAuthorityInformationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/AmendRegistrationAuthorityInformationType.php
@@ -39,15 +39,11 @@ class AmendRegistrationAuthorityInformationType extends AbstractType
                 'label' => 'ra.management.form.amend_ra_info.label.amend_ra_info',
                 'attr' => ['class' => 'btn btn-primary pull-right']
             ])
-            ->add(
-                'cancel',
-                'anchor',
-                [
-                    'label' => 'ra.management.form.amend_ra_info.label.cancel',
-                    'route' => 'ra_management_manage',
-                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
-                ]
-            )
+            ->add('cancel', AnchorType::class, [
+                'label' => 'ra.management.form.amend_ra_info.label.cancel',
+                'route' => 'ra_management_manage',
+                'attr'  => ['class' => 'btn btn-link pull-right cancel']
+            ])
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/AmendRegistrationAuthorityInformationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/AmendRegistrationAuthorityInformationType.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,13 +29,13 @@ class AmendRegistrationAuthorityInformationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('location', 'textarea', [
+            ->add('location', TextareaType::class, [
                 'label' => 'ra.management.form.amend_ra_info.label.location'
             ])
-            ->add('contactInformation', 'textarea', [
+            ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.management.form.amend_ra_info.label.contact_information'
             ])
-            ->add('amend_ra_info', 'submit', [
+            ->add('amend_ra_info', SubmitType::class, [
                 'label' => 'ra.management.form.amend_ra_info.label.amend_ra_info',
                 'attr' => ['class' => 'btn btn-primary pull-right']
             ])
@@ -56,7 +58,7 @@ class AmendRegistrationAuthorityInformationType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_management_amend_ra_info';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/AnchorType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/AnchorType.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ButtonTypeInterface;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,10 +29,10 @@ class AnchorType extends AbstractType implements ButtonTypeInterface
 {
     public function getParent()
     {
-        return 'button';
+        return ButtonType::class;
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'anchor';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/AnchorType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/AnchorType.php
@@ -47,10 +47,8 @@ class AnchorType extends AbstractType implements ButtonTypeInterface
 
         $resolver->setRequired(['route']);
 
-        $resolver->setAllowedTypes([
-            'route'            => 'string',
-            'route_parameters' => 'array',
-        ]);
+        $resolver->setAllowedTypes('route', 'string');
+        $resolver->setAllowedTypes('route_parameters', 'array');
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaLocationType.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -30,13 +32,13 @@ class ChangeRaLocationType extends AbstractType
             ->add('name', null, [
                 'label' => 'ra.form.ra_search_ra_candidates.label.name',
             ])
-            ->add('location', 'textarea', [
+            ->add('location', TextareaType::class, [
                 'label' => 'ra.management.form.change_ra.label.location'
             ])
-            ->add('contactInformation', 'textarea', [
+            ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.management.form.change_ra.label.contact_information'
             ])
-            ->add('change_ra_location', 'submit', [
+            ->add('change_ra_location', SubmitType::class, [
                 'label' => 'ra.management.form.change_ra_location.label.change_ra_location',
                 'attr' => ['class' => 'btn btn-primary pull-right change-ra-location']
             ])
@@ -59,7 +61,7 @@ class ChangeRaLocationType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_change_ra_location';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaLocationType.php
@@ -42,15 +42,11 @@ class ChangeRaLocationType extends AbstractType
                 'label' => 'ra.management.form.change_ra_location.label.change_ra_location',
                 'attr' => ['class' => 'btn btn-primary pull-right change-ra-location']
             ])
-            ->add(
-                'cancel',
-                'anchor',
-                [
-                    'label' => 'ra.management.form.change_ra_location.label.cancel',
-                    'route' => 'ra_locations_manage',
-                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
-                ]
-            )
+            ->add('cancel', AnchorType::class, [
+                'label' => 'ra.management.form.change_ra_location.label.cancel',
+                'route' => 'ra_locations_manage',
+                'attr' => ['class' => 'btn btn-link pull-right cancel'],
+            ])
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaRoleType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaRoleType.php
@@ -20,20 +20,22 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Surfnet\StepupRa\RaBundle\Form\Extension\RaRoleChoiceList;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChangeRaRoleType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('role', 'choice', [
+            ->add('role', ChoiceType::class, [
                 'label'       => 'ra.management.form.change_ra_role.label.role',
                 'choices' => RaRoleChoiceList::create(),
                 'choices_as_values' => true,
             ])
-            ->add('create_ra', 'submit', [
+            ->add('create_ra', SubmitType::class, [
                 'label' => 'ra.management.form.change_ra_role.label.save',
                 'attr'  => ['class' => 'btn btn-primary pull-right change-ra-role']
             ])
@@ -44,14 +46,14 @@ class ChangeRaRoleType extends AbstractType
             ]);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'data_class' => 'Surfnet\StepupRa\RaBundle\Command\ChangeRaRoleCommand'
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_management_change_ra_role';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaRoleType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaRoleType.php
@@ -39,7 +39,7 @@ class ChangeRaRoleType extends AbstractType
                 'label' => 'ra.management.form.change_ra_role.label.save',
                 'attr'  => ['class' => 'btn btn-primary pull-right change-ra-role']
             ])
-            ->add('cancel', 'anchor', [
+            ->add('cancel', AnchorType::class, [
                 'label' => 'ra.management.form.create_ra.label.cancel',
                 'route' => 'ra_management_ra_candidate_search',
                 'attr'  => ['class' => 'btn btn-link pull-right cancel']

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaLocationType.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -30,13 +32,13 @@ class CreateRaLocationType extends AbstractType
             ->add('name', null, [
                 'label' => 'ra.form.ra_create_ra_location.label.name',
             ])
-            ->add('location', 'textarea', [
+            ->add('location', TextareaType::class, [
                 'label' => 'ra.form.ra_create_ra_location.label.location'
             ])
-            ->add('contactInformation', 'textarea', [
+            ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.form.ra_create_ra_location.label.contact_information'
             ])
-            ->add('create_ra_location', 'submit', [
+            ->add('create_ra_location', SubmitType::class, [
                 'label' => 'ra.form.ra_create_ra_location.label.create_ra_location',
                 'attr' => ['class' => 'btn btn-primary pull-right create-ra-location']
             ])
@@ -59,7 +61,7 @@ class CreateRaLocationType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_create_ra_location';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaLocationType.php
@@ -42,15 +42,11 @@ class CreateRaLocationType extends AbstractType
                 'label' => 'ra.form.ra_create_ra_location.label.create_ra_location',
                 'attr' => ['class' => 'btn btn-primary pull-right create-ra-location']
             ])
-            ->add(
-                'cancel',
-                'anchor',
-                [
-                    'label' => 'ra.form.ra_create_ra_location.label.cancel',
-                    'route' => 'ra_locations_manage',
-                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
-                ]
-            )
+            ->add('cancel', AnchorType::class, [
+                'label' => 'ra.form.ra_create_ra_location.label.cancel',
+                'route' => 'ra_locations_manage',
+                'attr'  => ['class' => 'btn btn-link pull-right cancel']
+            ])
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
@@ -20,6 +20,9 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Surfnet\StepupRa\RaBundle\Form\Extension\RaRoleChoiceList;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -28,18 +31,18 @@ class CreateRaType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('location', 'textarea', [
+            ->add('location', TextareaType::class, [
                 'label' => 'ra.management.form.create_ra.label.location'
             ])
-            ->add('contactInformation', 'textarea', [
+            ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.management.form.create_ra.label.contact_information'
             ])
-            ->add('role', 'choice', [
+            ->add('role', ChoiceType::class, [
                 'label' => 'ra.management.form.create_ra.label.role',
                 'choices' => RaRoleChoiceList::create(),
                 'choices_as_values' => true,
             ])
-            ->add('create_ra', 'submit', [
+            ->add('create_ra', SubmitType::class, [
                 'label' => 'ra.management.form.create_ra.label.create_ra',
                 'attr' => ['class' => 'btn btn-primary pull-right create-ra']
             ])
@@ -62,7 +65,7 @@ class CreateRaType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_management_create_ra';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
@@ -46,15 +46,11 @@ class CreateRaType extends AbstractType
                 'label' => 'ra.management.form.create_ra.label.create_ra',
                 'attr' => ['class' => 'btn btn-primary pull-right create-ra']
             ])
-            ->add(
-                'cancel',
-                'anchor',
-                [
-                    'label' => 'ra.management.form.create_ra.label.cancel',
-                    'route' => 'ra_management_ra_candidate_search',
-                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
-                ]
-            )
+            ->add('cancel', AnchorType::class, [
+                'label' => 'ra.management.form.create_ra.label.cancel',
+                'route' => 'ra_management_ra_candidate_search',
+                'attr'  => ['class' => 'btn btn-link pull-right cancel']
+            ])
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/InitiateGssfType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/InitiateGssfType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
@@ -43,7 +44,7 @@ class InitiateGssfType extends AbstractType
         );
 
         $builder
-            ->add('submit', 'submit', [
+            ->add('submit', SubmitType::class, [
                 'attr'  => ['class' => 'btn btn-primary'],
                 /** @Ignore */
                 'label' => $options['label']
@@ -58,7 +59,7 @@ class InitiateGssfType extends AbstractType
         $resolver->setAllowedTypes('provider', 'string');
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_initiate_gssf';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/InstitutionSelectionType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/InstitutionSelectionType.php
@@ -20,6 +20,8 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Surfnet\StepupRa\RaBundle\Form\Extension\InstitutionListingChoiceList;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -35,12 +37,12 @@ class InstitutionSelectionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('institution', 'choice', [
+            ->add('institution', ChoiceType::class, [
                 'choices' => $this->institutionListingChoiceList->create(),
                 'choices_as_values' => true,
                 'label' => 'ra.form.ra_select_institution.label.institution',
             ])
-            ->add('select_and_apply', 'submit', [
+            ->add('select_and_apply', SubmitType::class, [
                 'label' => 'ra.form.ra_select_institution.button.select_and_apply',
                 'attr'  => ['class' => 'btn btn-primary pull-right'],
             ]);
@@ -58,7 +60,7 @@ class InstitutionSelectionType extends AbstractType
      *
      * @return string The name of this type
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'sraa_institution_select';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RemoveRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RemoveRaLocationType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,8 +28,8 @@ class RemoveRaLocationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('locationId', 'hidden')
-            ->add('institution', 'hidden');
+            ->add('locationId', HiddenType::class)
+            ->add('institution', HiddenType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -38,7 +39,7 @@ class RemoveRaLocationType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_remove_ra_location';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RetractRegistrationAuthorityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RetractRegistrationAuthorityType.php
@@ -19,32 +19,33 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RetractRegistrationAuthorityType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('confirm', 'submit', [
+            ->add('confirm', SubmitType::class, [
                 'attr' => ['class' => 'btn btn-warning pull-right'],
                 'label' => 'ra.management.retract_ra.modal.confirm',
             ])
-            ->add('cancel', 'submit', [
+            ->add('cancel', SubmitType::class, [
                 'attr' => ['class' => 'btn btn-info pull-right'],
                 'label' => 'ra.management.retract_ra.modal.cancel',
             ]);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'data_class' => 'Surfnet\StepupRa\RaBundle\Command\RetractRegistrationAuthorityCommand'
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_management_retract_registration_authority';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RevokeSecondFactorType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RevokeSecondFactorType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,8 +28,8 @@ class RevokeSecondFactorType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('secondFactorId', 'hidden')
-            ->add('identityId', 'hidden');
+            ->add('secondFactorId', HiddenType::class)
+            ->add('identityId', HiddenType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -38,7 +39,7 @@ class RevokeSecondFactorType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_revoke_second_factor';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -33,7 +34,7 @@ class SearchRaCandidatesType extends AbstractType
             ->add('email', null, [
                 'label' => 'ra.form.ra_search_ra_candidates.label.email',
             ])
-            ->add('search', 'submit', [
+            ->add('search', SubmitType::class, [
                 'label' => 'ra.form.ra_search_ra_candidates.button.search',
                 'attr'  => ['class' => 'btn btn-primary'],
             ]);
@@ -46,7 +47,7 @@ class SearchRaCandidatesType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_search_ra_candidates';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php
@@ -20,6 +20,8 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Surfnet\StepupRa\RaBundle\Form\Extension\SecondFactorTypeChoiceList;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -40,7 +42,7 @@ class SearchRaSecondFactorsType extends AbstractType
         $builder->add('name', null, [
             'label' => 'ra.form.ra_search_ra_second_factors.label.name',
         ]);
-        $builder->add('type', 'choice', [
+        $builder->add('type', ChoiceType::class, [
             'label' => 'ra.form.ra_search_ra_second_factors.label.type',
             'choices' => $this->secondFactorTypeChoiseList->create(),
             'required' => false,
@@ -51,7 +53,7 @@ class SearchRaSecondFactorsType extends AbstractType
         $builder->add('email', null, [
             'label' => 'ra.form.ra_search_ra_second_factors.label.email',
         ]);
-        $builder->add('status', 'choice', [
+        $builder->add('status', ChoiceType::class, [
             'label' => 'ra.form.ra_search_ra_second_factors.label.status',
             'choices' => [
                 'unverified' => 'ra.form.ra_search_ra_second_factors.choice.status.unverified',
@@ -61,12 +63,12 @@ class SearchRaSecondFactorsType extends AbstractType
             ],
             'required' => false,
         ]);
-        $builder->add('search', 'submit', [
+        $builder->add('search', SubmitType::class, [
             'label' => 'ra.form.ra_search_ra_second_factors.button.search',
             'attr' => [ 'class' => 'btn btn-primary pull-left' ],
         ]);
 
-        $builder->add('export', 'submit', [
+        $builder->add('export', SubmitType::class, [
             'label' => 'ra.form.ra_search_ra_second_factors.button.export',
             'attr' => [ 'class' => 'btn btn-secondary pull-left' ],
         ]);
@@ -79,7 +81,7 @@ class SearchRaSecondFactorsType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_search_ra_second_factors';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SendSmsChallengeType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SendSmsChallengeType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,7 +27,7 @@ class SendSmsChallengeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('send-challenge', 'submit', [
+        $builder->add('send-challenge', SubmitType::class, [
             'label' => 'ra.form.ra_send_sms_challenge.button.send_challenge',
             'attr' => [ 'class' => 'btn btn-primary' ],
         ]);
@@ -39,7 +40,7 @@ class SendSmsChallengeType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_send_sms_challenge';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/StartVettingProcedureType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/StartVettingProcedureType.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,7 +28,7 @@ class StartVettingProcedureType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('registrationCode', 'text', [
+        $builder->add('registrationCode', TextType::class, [
             'label' => /** @Ignore */ false,
             'required' => true,
             'widget_addon_prepend' => [
@@ -38,7 +40,7 @@ class StartVettingProcedureType extends AbstractType
                 'placeholder' => 'ra.form.start_vetting_procedure.enter_activation_code_here',
             )
         ]);
-        $builder->add('search', 'submit', [
+        $builder->add('search', SubmitType::class, [
             'label' => 'ra.form.start_vetting_procedure.search',
             'attr' => [ 'class' => 'btn btn-primary' ],
         ]);
@@ -51,7 +53,7 @@ class StartVettingProcedureType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_start_vetting_procedure';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
@@ -19,6 +19,9 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
@@ -27,7 +30,7 @@ class VerifyIdentityType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('documentNumber', 'text', [
+        $builder->add('documentNumber', TextType::class, [
             'label' => 'ra.form.verify_identity.document_number.label',
             'horizontal_label_class' => 'col-sm-6 left-aligned',
             'horizontal_input_wrapper_class' => 'col-sm-6',
@@ -38,16 +41,16 @@ class VerifyIdentityType extends AbstractType
                 'novalidate' => true
             ]
         ]);
-        $builder->add('identityVerified', 'checkbox', [
+        $builder->add('identityVerified', CheckboxType::class, [
             'label' => 'ra.form.verify_identity.identity_verified.label',
             'widget_checkbox_label' => 'widget',
             'widget_form_group_attr' => ['class' => 'form-group form-group-verify-identity'],
         ]);
-        $builder->add('verifyIdentity', 'submit', [
+        $builder->add('verifyIdentity', SubmitType::class, [
             'label' => 'ra.form.verify_identity.verify_identity.button',
             'attr' => [ 'class' => 'btn btn-primary pull-right' ],
         ]);
-        $builder->add('cancel', 'submit', [
+        $builder->add('cancel', SubmitType::class, [
             'label' => 'ra.vetting.button.cancel_procedure',
             'attr' => [ 'class' => 'btn btn-danger' ],
         ]);
@@ -60,7 +63,7 @@ class VerifyIdentityType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_verify_identity';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
@@ -24,7 +24,6 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\Length;
 
 class VerifyIdentityType extends AbstractType
 {

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
@@ -39,7 +39,7 @@ class VerifyPhoneNumberType extends AbstractType
             'label' => 'ra.form.ra_verify_phone_number.button.verify_challenge',
             'attr' => [ 'class' => 'btn btn-primary pull-right' ],
         ]);
-        $builder->add('resendChallenge', 'anchor', [
+        $builder->add('resendChallenge', AnchorType::class, [
             'label' => 'ra.form.ra_verify_phone_number.button.resend_challenge',
             'attr' => [ 'class' => 'btn btn-default' ],
             'route' => 'ra_vetting_sms_send_challenge',

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
@@ -19,6 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,14 +28,14 @@ class VerifyPhoneNumberType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('challenge', 'text', [
+        $builder->add('challenge', TextType::class, [
             'label' => 'ra.form.ra_verify_phone_number.text.challenge',
             'required' => true,
             'attr' => array(
                 'autofocus' => true,
             ),
         ]);
-        $builder->add('verifyChallenge', 'submit', [
+        $builder->add('verifyChallenge', SubmitType::class, [
             'label' => 'ra.form.ra_verify_phone_number.button.verify_challenge',
             'attr' => [ 'class' => 'btn btn-primary pull-right' ],
         ]);
@@ -43,7 +45,7 @@ class VerifyPhoneNumberType extends AbstractType
             'route' => 'ra_vetting_sms_send_challenge',
             'route_parameters' => ['procedureId' => $options['procedureId']],
         ]);
-        $builder->add('cancel', 'submit', [
+        $builder->add('cancel', SubmitType::class, [
             'label' => 'ra.vetting.button.cancel_procedure',
             'attr' => [ 'class' => 'btn btn-danger' ],
         ]);
@@ -63,7 +65,7 @@ class VerifyPhoneNumberType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_verify_phone_number';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyYubikeyPublicIdType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyYubikeyPublicIdType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,7 +27,7 @@ class VerifyYubikeyPublicIdType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('otp', 'text', [
+        $builder->add('otp', TextType::class, [
             'label' => /** @Ignore */ false,
             'required' => true,
             'widget_addon_prepend' => [
@@ -46,7 +47,7 @@ class VerifyYubikeyPublicIdType extends AbstractType
         ]);
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'ra_verify_yubikey_public_id';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
@@ -31,7 +31,7 @@ services:
         public: false
         class: Surfnet\StepupBundle\Value\Loa
         factory: ["@surfnet_stepup.service.loa_resolution", getLoa]
-        arguments: [%surfnet_stepup_ra.security.required_loa%]
+        arguments: ["%surfnet_stepup_ra.security.required_loa%"]
 
     # Authentication Handlers
     ra.security.authentication.handler.authenticated_user_handler:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -1,4 +1,12 @@
 services:
+    # To be compatible with loading services from the container instead of using DI, TODO, Utilize DI throughout the
+    # application.
+    _defaults: { public: true }
+
+    logger:
+      alias: 'monolog.logger'
+      public: true
+
     ra.service.command:
         class: Surfnet\StepupRa\RaBundle\Service\CommandService
         arguments:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -1,4 +1,4 @@
-@import "../../../../../../../vendor/mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/bootstrap-fontawesome4.less";
+@import "../../../../../../../vendor/mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/bootstrap-fontawesome.less";
 
 // overriding the font path for correct loading.
 @FontAwesomePath: "/fonts";

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -4,6 +4,20 @@
 @FontAwesomePath: "/fonts";
 @fa-font-path: "/fonts";
 
+// This override of the mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/font-awesome/path.less
+// prevents loading of the none existing woff2 file that resulted in four oh fours.
+@font-face {
+    font-family: 'FontAwesome';
+    src: url('@{fa-font-path}/fontawesome-webfont.eot?v=@{fa-version}');
+    src: url('@{fa-font-path}/fontawesome-webfont.eot?#iefix&v=@{fa-version}') format('embedded-opentype'),
+    url('@{fa-font-path}/fontawesome-webfont.woff?v=@{fa-version}') format('woff'),
+    url('@{fa-font-path}/fontawesome-webfont.ttf?v=@{fa-version}') format('truetype'),
+    url('@{fa-font-path}/fontawesome-webfont.svg?v=@{fa-version}#fontawesomeregular') format('svg');
+    //  src: url('@{fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
+    font-weight: normal;
+    font-style: normal;
+}
+
 .progress-steps {
     font-size: 110%;
 }

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -23,12 +23,12 @@ use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
 use Surfnet\StepupRa\RaBundle\Exception\InconsistentStateException;
 use Surfnet\StepupRa\RaBundle\Exception\MissingRequiredAttributeException;
+use Surfnet\StepupRa\RaBundle\Exception\UserNotRaException;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Service\IdentityService;
 use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Surfnet\StepupRa\RaBundle\Exception\UserNotRaException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 class SamlProvider implements AuthenticationProviderInterface

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Session/SessionStorage.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Session/SessionStorage.php
@@ -19,8 +19,8 @@
 namespace Surfnet\StepupRa\RaBundle\Security\Authentication\Session;
 
 use Surfnet\StepupRa\RaBundle\Exception\LogicException;
-use Surfnet\StepupRa\RaBundle\Security\Authentication\SamlAuthenticationStateHandler;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\AuthenticatedSessionStateHandler;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\SamlAuthenticationStateHandler;
 use Surfnet\StepupRa\RaBundle\Value\DateTime;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 

--- a/web/app.php
+++ b/web/app.php
@@ -2,14 +2,16 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-
-require_once __DIR__.'/../app/AppKernel.php';
-
-$kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
+$loader = require __DIR__.'/../app/autoload.php';
 
 $request = Request::createFromGlobals();
+
+$kernel = new AppKernel('prod', false);
+$kernel->boot();
+
+$trustedProxies = $kernel->getContainer()->getParameter('trusted_proxies');
+Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_ALL);
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
This PR installs Symfony 3.4 and tries to changes as little application code as possible. The following changes  have been made:
* Updated composer dependencies to allow 3.4 installation
* Changes in code to fix/prevent deprecation warnings

Todo's that need to be fixed before merging:
- [x] Update the Stepup-* bundles in composer.json once they are released to a suitable new version.

Other todos that are left in place are:
* Get rid of using the service container in every controller, use DI instead
* Utilize autowire/autoconfigure
* Replace Assetic for a more straight forward frontend dependency management solution.