### PR TITLE
Use flash messages for error messaging

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php
@@ -95,7 +95,7 @@ final class RaLocationController extends Controller
             }
 
             $logger->debug('RA Location creation failed, adding error to form');
-            $form->addError(new FormError('ra.create_ra_location.error.middleware_command_failed'));
+            $this->addFlash('error', 'ra.create_ra_location.error.middleware_command_failed');
         }
 
         return $this->render('SurfnetStepupRaRaBundle:RaLocation:create.html.twig', [
@@ -156,7 +156,7 @@ final class RaLocationController extends Controller
             }
 
             $logger->debug('RA Location creation failed, adding error to form');
-            $form->addError(new FormError('ra.create_ra_location.error.middleware_command_failed'));
+            $this->addFlash('error', 'ra.create_ra_location.error.middleware_command_failed');
         }
 
         return $this->render('SurfnetStepupRaRaBundle:RaLocation:change.html.twig', [

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -176,7 +176,7 @@ class RaManagementController extends Controller
             }
 
             $logger->debug('Identity Accreditation failed, adding error to form');
-            $form->addError(new FormError('ra.management.create_ra.error.middleware_command_failed'));
+            $this->addFlash('error', 'ra.management.create_ra.error.middleware_command_failed');
         }
 
         return $this->render('SurfnetStepupRaRaBundle:RaManagement:createRa.html.twig', [
@@ -221,7 +221,7 @@ class RaManagementController extends Controller
             }
 
             $logger->notice(sprintf("Information of RA(A) '%s' failed to be amended, informing user", $identityId));
-            $form->addError(new FormError('ra.management.amend_ra_info.error.middleware_command_failed'));
+            $this->addFlash('error', 'ra.management.amend_ra_info.error.middleware_command_failed');
         }
 
         return $this->render('SurfnetStepupRaRaBundle:RaManagement:amendRaInformation.html.twig', [
@@ -265,7 +265,7 @@ class RaManagementController extends Controller
             }
 
             $logger->notice(sprintf('Role of RA(A) "%s" could not be changed, informing user', $identityId));
-            $form->addError(new FormError('ra.management.change_ra_role.middleware_command_failed'));
+            $this->addFlash('error', 'ra.management.change_ra_role.middleware_command_failed');
         }
 
         return $this->render('SurfnetStepupRaRaBundle:RaManagement:changeRaRole.html.twig', [
@@ -315,7 +315,7 @@ class RaManagementController extends Controller
                 'Could not retract Registration Authority credentials for identity "%s"',
                 $identityId
             ));
-            $form->addError(new FormError('ra.management.retract_ra.middleware_command_failed'));
+            $this->addFlash('error', 'ra.management.retract_ra.middleware_command_failed');
         }
 
         return $this->render('SurfnetStepupRaRaBundle:RaManagement:confirmRetractRa.html.twig', [

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/SmsController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/SmsController.php
@@ -82,7 +82,7 @@ class SmsController extends SecondFactorController
             return $this->redirectToRoute('ra_vetting_sms_prove_possession', ['procedureId' => $procedureId]);
         }
 
-        $form->addError(new FormError('ra.sms_send_challenge.send_sms_challenge_failed'));
+        $this->addFlash('error', 'ra.sms_send_challenge.send_sms_challenge_failed');
 
         $logger->notice(
             'SMS Challenge could not be sent, added error to page to notify user and re-rendering send challenge page'
@@ -140,11 +140,11 @@ class SmsController extends SecondFactorController
                 ['procedureId' => $procedureId]
             );
         } elseif ($verification->didOtpExpire()) {
-            $form->addError(new FormError('ra.prove_phone_possession.challenge_expired'));
+            $this->addFlash('error', 'ra.prove_phone_possession.challenge_expired');
         } elseif ($verification->wasAttemptedTooManyTimes()) {
-            $form->addError(new FormError('ra.prove_phone_possession.too_many_attempts'));
+            $this->addFlash('error', 'ra.prove_phone_possession.too_many_attempts');
         } else {
-            $form->addError(new FormError('ra.prove_phone_possession.challenge_response_incorrect'));
+            $this->addFlash('error', 'ra.prove_phone_possession.challenge_response_incorrect');
         }
 
         $logger->notice('SMS OTP verification failed - Proof of Possession denied, added error to form');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/Vetting/YubikeyController.php
@@ -61,11 +61,11 @@ class YubikeyController extends SecondFactorController
             }
 
             if ($result->wasOtpInvalid()) {
-                $form->addError(new FormError('ra.verify_yubikey_command.otp.otp_invalid'));
+                $this->addFlash('error', 'ra.verify_yubikey_command.otp.otp_invalid');
             } elseif ($result->didOtpVerificationFail()) {
-                $form->addError(new FormError('ra.verify_yubikey_command.otp.verification_error'));
+                $this->addFlash('error', 'ra.verify_yubikey_command.otp.verification_error');
             } else {
-                $form->addError(new FormError('ra.prove_yubikey_possession.different_yubikey_used'));
+                $this->addFlash('error', 'ra.prove_yubikey_possession.different_yubikey_used');
             }
 
             $logger->notice('Yubikey could not be verified, added error to form');

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -71,14 +71,14 @@ class VettingController extends Controller
             ->findVerifiedSecondFactorByRegistrationCode($command->registrationCode);
 
         if ($secondFactor === null) {
-            $form->addError(new FormError('ra.form.start_vetting_procedure.unknown_registration_code'));
+            $this->addFlash('error', 'ra.form.start_vetting_procedure.unknown_registration_code');
             $logger->notice('Cannot start new vetting procedure, no second factor found');
 
             return ['form' => $form->createView()];
         }
 
         if (!$this->isGranted('ROLE_SRAA') && $secondFactor->institution !== $this->getIdentity()->institution) {
-            $form->addError(new FormError('ra.form.start_vetting_procedure.different_institution_error'));
+            $this->addFlash('error', 'ra.form.start_vetting_procedure.different_institution_error');
             $logger->notice(
                 'Cannot start new vetting procedure, registrant belongs to a different institution than RA'
             );
@@ -111,16 +111,15 @@ class VettingController extends Controller
         $command->secondFactor = $secondFactor;
 
         if ($this->getVettingService()->isExpiredRegistrationCode($command)) {
-            $form->addError(
-                new FormError(
-                    $this->getTranslator()
-                        ->trans(
-                            'ra.verify_identity.registration_code_expired',
-                            [
-                                '%self_service_url%' => $this->getParameter('surfnet_stepup_ra.self_service_url'),
-                            ]
-                        )
-                )
+            $this->addFlash(
+                'error',
+                $this->getTranslator()
+                    ->trans(
+                        'ra.verify_identity.registration_code_expired',
+                        [
+                            '%self_service_url%' => $this->getParameter('surfnet_stepup_ra.self_service_url'),
+                        ]
+                    )
             );
 
             $logger->notice(
@@ -132,7 +131,7 @@ class VettingController extends Controller
         }
 
         if (!$this->getVettingService()->isLoaSufficientToStartProcedure($command)) {
-            $form->addError(new FormError('ra.form.start_vetting_procedure.loa_insufficient'));
+            $this->addFlash('error', 'ra.form.start_vetting_procedure.loa_insufficient');
 
             $logger->notice('Cannot start new vetting procedure, Authority LoA is insufficient');
 
@@ -217,7 +216,7 @@ class VettingController extends Controller
 
         $showForm = function ($error = null) use ($form, $commonName) {
             if ($error) {
-                $form->addError(new FormError($error));
+                $this->addFlash('error', $error);
             }
 
             return ['commonName' => $commonName, 'form' => $form->createView()];


### PR DESCRIPTION
The addError construction expects translated messages. The translator
is not available in the controllers and adding extra coupling was
not preferred over changing to flash messages.

See: https://www.pivotaltracker.com/story/show/160228972