### PR TITLE
Provide Behat support in RA

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,5 +1,6 @@
 imports:
     - { resource: config_dev.yml }
+    - { resource: service_test.yml }
 
 framework:
     test: ~

--- a/app/config/service_test.yml
+++ b/app/config/service_test.yml
@@ -1,0 +1,5 @@
+services:
+  surfnet_stepup.service.sms_second_factor:
+    class: Surfnet\StepupBundle\Tests\TestDouble\Service\SmsSecondFactorService
+    arguments:
+      - "@surfnet_stepup.service.challenge_handler"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae8e40f45a1d3152a3c54f4ac9c29060",
+    "content-hash": "ad296108577f810d86cba201d17fe756",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2213,16 +2213,16 @@
         },
         {
             "name": "surfnet/stepup-bundle",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-bundle.git",
-                "reference": "5946dde19d5e095a5836d602b7abfa64cb71d6f1"
+                "reference": "3329ca027f57208d7a20882707ef4a01dd2a4fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/5946dde19d5e095a5836d602b7abfa64cb71d6f1",
-                "reference": "5946dde19d5e095a5836d602b7abfa64cb71d6f1",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-bundle/zipball/3329ca027f57208d7a20882707ef4a01dd2a4fb6",
+                "reference": "3329ca027f57208d7a20882707ef4a01dd2a4fb6",
                 "shasum": ""
             },
             "require": {
@@ -2265,7 +2265,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2018-09-06T12:43:15+00:00"
+            "time": "2018-09-13T14:13:26+00:00"
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
@@ -60,9 +60,7 @@ class VerifyPhoneNumberType extends AbstractType
 
         $resolver->setRequired(['procedureId']);
 
-        $resolver->setAllowedTypes([
-            'procedureId' => 'string',
-        ]);
+        $resolver->setAllowedTypes('procedureId', 'string');
     }
 
     public function getBlockPrefix()

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingService.php
@@ -23,7 +23,7 @@ use Surfnet\StepupBundle\Command\SendSmsChallengeCommand;
 use Surfnet\StepupBundle\Command\VerifyPossessionOfPhoneCommand;
 use Surfnet\StepupBundle\Service\SecondFactorTypeService;
 use Surfnet\StepupBundle\Service\SmsSecondFactor\OtpVerification;
-use Surfnet\StepupBundle\Service\SmsSecondFactorService;
+use Surfnet\StepupBundle\Service\SmsSecondFactorServiceInterface;
 use Surfnet\StepupBundle\Value\PhoneNumber\InternationalPhoneNumber;
 use Surfnet\StepupBundle\Value\SecondFactorType;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Command\VetSecondFactorCommand;
@@ -57,7 +57,7 @@ class VettingService
         'Surfnet\Stepup\Exception\DomainException: Cannot vet second factor, the registration window is closed.';
 
     /**
-     * @var \Surfnet\StepupBundle\Service\SmsSecondFactorService
+     * @var \Surfnet\StepupBundle\Service\SmsSecondFactorServiceInterface
      */
     private $smsSecondFactorService;
 
@@ -102,7 +102,7 @@ class VettingService
     private $secondFactorTypeService;
 
     public function __construct(
-        SmsSecondFactorService $smsSecondFactorService,
+        SmsSecondFactorServiceInterface $smsSecondFactorService,
         YubikeySecondFactorService $yubikeySecondFactorService,
         GssfService $gssfService,
         U2fService $u2fService,


### PR DESCRIPTION
The test double is used to prevent the sending of actual SMS messages to
 a test user.

In order to make the change work correctly, the VettingService now works
with the SmsSecondFactorServiceInterface. This interface will be
introduced in the upcoming Stepup-bundle release.