### PR TITLE
Correct the way allowed types are set

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyPhoneNumberType.php
@@ -60,9 +60,7 @@ class VerifyPhoneNumberType extends AbstractType
 
         $resolver->setRequired(['procedureId']);
 
-        $resolver->setAllowedTypes([
-            'procedureId' => 'string',
-        ]);
+        $resolver->setAllowedTypes('procedureId', 'string');
     }
 
     public function getBlockPrefix()


### PR DESCRIPTION
The OptionsResolver works differently in Symfony 3.4. This was not
correctly fixed in the previous commits for the VerifyPhoneNumberType.

The setAllowedTypes method is now called correctly. Preventing issues on
while processing the form.