### PR TITLE
Override the middleware api clients for smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## Develop
+
 **Bugfixes**
 * Flip value/label in choice form type definitions #168
+
+**Improvments for testing**
+* Ensure middleware API is used in test mode #167
 
 ## 2.10.2
 **Bugfixes**

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -18,3 +18,19 @@ nelmio_security:
         img: [ self, 'data:' ]
         script: [ self, unsafe-inline ]
         style: [ self, unsafe-inline ]
+
+surfnet_stepup_middleware_client:
+    authorisation:
+        password: secret
+
+surfnet_saml:
+    hosted:
+        service_provider:
+            public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+            private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+        metadata:
+            public_key: /vagrant/deploy/tests/behat/fixtures/test_public_key.crt
+            private_key: /vagrant/deploy/tests/behat/fixtures/test_private_key.key
+    remote:
+        identity_provider:
+            certificate: MIIC6jCCAdICCQC9cRx5wiwWOjANBgkqhkiG9w0BAQsFADA3MRwwGgYDVQQDDBNTZWxmU2VydmljZSBTQU1MIFNQMRcwFQYDVQQKDA5EZXZlbG9wbWVudCBWTTAeFw0xODA3MzAxMjMwNDdaFw0yMzA3MjkxMjMwNDdaMDcxHDAaBgNVBAMME1NlbGZTZXJ2aWNlIFNBTUwgU1AxFzAVBgNVBAoMDkRldmVsb3BtZW50IFZNMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhbI0Xy682DuvWchg6FYnI+DNwLXef2XExM4YVRBaMMsOZ3rBtQUTMSqYan6SK/BOEXLs0rNiJjyM0dn+F98wg3fv5zIADlvfk3LBVdcGsrpVfFUWtSa73yMgbROy8/RJADbUJE/HUB3ZmdjdiuD2Cui2aoWwT2HR8ukJwmoxiu45IWFPbqPQ7/1mH644JPOWTPLTv4OGGLQo8MNrP1oRCiZ0IEL4CQeGOOju5rfIJ0bTVm0UmelT4hGaqZovBMwXp3QV41akJ7UEMEBK2YMnLQy47Xuzi7aTDhJlvHcJ8mfH2NbjRh7hJoACVRTvQloxajgkr1iGMiWiiqT0e+YYwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBwZ0gRHvR8B8KivrXrhWNL9uLvWhEAH7OiDqo+fywkBp5KEuDJcbbvEPftHunSAGylg7M2xKuBIGamFpp74WDJccrtZ1jJ4qqnacUDRQrTLqqMZKqGpFOU0xjKkSxSGRuMtGN9/7er/TeonjQ0XBvjYvTomy3b5aCLVWRvEfKu2g1sDd8uhr62RY/HfMgidEt7LHDolkCVg+6JzY3OTcgeHga3cvYObOYPplxw1YPq5+BqqxaUW4nfb5DtK33bZBYMeyV6BZtSggc5Z/19aPx/s0bf6ySTUyB3lRqe5d3etCns4bGidORCl/6EZiXwVcPvmYmxYXqmuNWfps7isUvo

--- a/app/config/service_test.yml
+++ b/app/config/service_test.yml
@@ -1,5 +1,30 @@
+# Use this service definition file to override services and parameters in the test environment.
+# For example to mock certain services, or override a parameter for test.
+
+parameters:
+  middleware_credentials_password: secret
+
 services:
   surfnet_stepup.service.sms_second_factor:
     class: Surfnet\StepupBundle\Tests\TestDouble\Service\SmsSecondFactorService
     arguments:
       - "@surfnet_stepup.service.challenge_handler"
+
+  # The middleware client bundle guzzle client is overloaded to be able to pass the testcookie to the ensure MW is
+  # loaded in test mode. This way people setting the testcookie in prod will not switch their mw api into testmode
+  # resulting in 500 errors.
+  surfnet_stepup_middleware_client.guzzle.api:
+    public: false
+    class: GuzzleHttp\Client
+    factory: ['Surfnet\StepupRa\RaBundle\Tests\TestDouble\Factory\GuzzleApiFactory', createApiGuzzleClient]
+    arguments:
+    - "%middleware_url_api%"
+    - "%middleware_credentials_username%"
+    - "%middleware_credentials_password%"
+
+  surfnet_stepup_middleware_client.guzzle.commands:
+    public: false
+    class: GuzzleHttp\Client
+    factory: ['Surfnet\StepupRa\RaBundle\Tests\TestDouble\Factory\GuzzleApiFactory', createCommandGuzzleClient]
+    arguments:
+    - "%middleware_url_command_api%"

--- a/src/Surfnet/StepupRa/RaBundle/Tests/TestDouble/Factory/GuzzleApiFactory.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/TestDouble/Factory/GuzzleApiFactory.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\TestDouble\Factory;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+
+/**
+ * This factory builds replacements for the Guzzle clients that are normally provided by the middleware bundle. The
+ * added extra in this factory is that the testcookie is added to the configuration.
+ */
+class GuzzleApiFactory
+{
+    /**
+     * @param $apiUri
+     * @param $username
+     * @param $password
+     * @return Client
+     * 
+     * @see \Surfnet\StepupMiddlewareClientBundle\DependencyInjection\SurfnetStepupMiddlewareClientExtension::configureMiddlewareReadApiClient
+     */
+    public static function createApiGuzzleClient($apiUri, $username, $password)
+    {
+        $arguments = [
+            'base_uri' => $apiUri,
+            'auth' => [
+                $username,
+                $password,
+                'basic',
+            ],
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'cookies' => self::makeCookieJar($apiUri),
+        ];
+
+        return new Client($arguments);
+    }
+
+    /**
+     * @param $apiUri
+     * @return Client
+     * 
+     * @see \Surfnet\StepupMiddlewareClientBundle\DependencyInjection\SurfnetStepupMiddlewareClientExtension::configureMiddlewareCommandApiUrl
+     */
+    public static function createCommandGuzzleClient($apiUri)
+    {
+        return new Client(
+            [
+                'base_uri' => $apiUri,
+                'cookies' => self::makeCookieJar($apiUri),
+            ]
+        );
+    }
+
+    /**
+     * @param string $uri
+     * @return CookieJar
+     */
+    private static function makeCookieJar($uri)
+    {
+        $cookieDomain = parse_url($uri, PHP_URL_HOST);
+
+        return CookieJar::fromArray(
+            [
+                'testcookie' => 'testcookie',
+            ],
+            $cookieDomain
+        );
+    }
+}


### PR DESCRIPTION
In order to use the middleware api in test mode, guzzle needs to be
configured to pass along the testcookie. Otherwise middleware will
not know it is dealing with a test call.

See: https://www.pivotaltracker.com/story/show/160318902