### PR TITLE
Disable sorting on document number

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -29,7 +29,7 @@ div.page-header {
     }
 }
 
-table th {
+table.orderable th {
     color: @brand-primary;
 }
 

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -29,6 +29,10 @@ div.page-header {
     }
 }
 
+table th {
+    color: @brand-primary;
+}
+
 .ra-start-vetting-procedure-container {
     margin: 3em auto;
     max-width: 500px;

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig
@@ -6,7 +6,7 @@
             <a href="{{ path('ra_management_ra_candidate_search') }}" class="btn btn-primary pull-right" role="button">
                 <i class="fa fa-plus"></i> {{ 'ra.management.overview.add_raa'|trans }}
             </a>
-            <table class="table table-striped">
+            <table class="table table-striped orderable">
                 <thead>
                     <tr>
                         <th>{{ 'ra.management.overview.institution'|trans }}</th>

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/raCandidateOverview.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/raCandidateOverview.html.twig
@@ -5,7 +5,7 @@
             {{ form(form) }}
             <hr>
         {% if raCandidates.elements|length > 0 %}
-            <table class="table table-striped">
+            <table class="table table-striped orderable">
                 <thead>
                     <tr>
                         <th>{{ 'ra.management.ra_candidate.institution'|trans }}</th>

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
@@ -20,7 +20,7 @@
             </div>
         </div>
     {% if auditLog.elements|length > 0 %}
-        <table class="table table-striped table-hover">
+        <table class="table table-striped table-hover orderable">
             <thead>
                 <tr>
                     <th scope="col">{{ knp_pagination_sortable(pagination, 'ra.auditlog.second_factor_identifier'|trans, 'secondFactorIdentifier') }}</th>

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
@@ -22,7 +22,7 @@
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.name'|trans, 'name') }}</th>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.institution'|trans, 'institution') }}</th>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.email'|trans, 'email') }}</th>
-                        <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.document_number'|trans, 'document_number') }}</th>
+                        <th>{{ 'ra.second_factor.search.column.document_number'|trans }}</th>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.status'|trans, 'status') }}</th>
                         <th></th>
                     </tr>

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
@@ -14,7 +14,7 @@
             <hr>
 
             {% if secondFactors.elements|length > 0 %}
-                <table class="table table-striped">
+                <table class="table table-striped orderable">
                     <thead>
                     <tr>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.second_factor_id'|trans, 'secondFactorId') }}</th>


### PR DESCRIPTION
This feature is broken, as middleware does not acknowledge and implement
the sorting on the document number.

Adding support for this might be taken up at a later stage and is
requested in this chore:

https://www.pivotaltracker.com/story/show/161310060