### PR TITLE
Create and test the AllowedInOtherInstitutionVoter

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php
@@ -25,6 +25,8 @@ use Surfnet\StepupRa\RaBundle\Command\SearchRaSecondFactorsCommand;
 use Surfnet\StepupRa\RaBundle\Command\SearchSecondFactorAuditLogCommand;
 use Surfnet\StepupRa\RaBundle\Form\Type\RevokeSecondFactorType;
 use Surfnet\StepupRa\RaBundle\Form\Type\SearchRaSecondFactorsType;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Context\InstitutionContext;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedInOtherInstitutionVoter;
 use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -174,7 +176,8 @@ final class SecondFactorController extends Controller
             throw new NotFoundHttpException();
         }
 
-        if ($identity->institution !== $this->getCurrentUser()->institution) {
+        $institutionContext = new InstitutionContext($identity->institution, $this->getCurrentUser()->institution);
+        if (!$this->isGranted(AllowedInOtherInstitutionVoter::VIEW_AUDITLOG, $institutionContext)) {
             $logger->warning(sprintf(
                 'User with Identity "%s" (%s) requested Identity "%s" (%s) of another institution, denying access',
                 $this->getCurrentUser()->id,

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
@@ -113,3 +113,12 @@ services:
         factory: [Surfnet\StepupRa\RaBundle\Value\TimeFrame, ofSeconds]
         arguments:
             - "%ra.security.authentication.session.maximum_relative_lifetime_in_seconds%"
+
+    # Voters
+    ra.security.authorization.allowed_in_other_institution_voter:
+        class: Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedInOtherInstitutionVoter
+        arguments:
+            - '@ra.service.institution_configuration_options'
+        tags:
+            - { name: security.voter }
+        public: false

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Context/InstitutionContext.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Context/InstitutionContext.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Context;
+
+/**
+ * Authorization context for FGA institution related authorization checks
+ * This context is set with the institution of the target (the identity
+ * that is operated on) and the actor (the logged in user with role:
+ * (S)RA(A)).
+ *
+ * The context is used in the RaInOtherInstitutionVoter, and can be used
+ * from the context of a controller or service that uses the AuthzChecker
+ *
+ * Example:
+ * $context = new InstitutionContext('institution-a', 'institution-d');
+ * $securityChecker->isGranted('view_auditlog', $context);
+ *
+ * @see RaInOtherInstitutionVoter
+ */
+final class InstitutionContext
+{
+    private $targetInstitution;
+
+    private $actorInstitution;
+
+    /**
+     * @param string $targetInstitution
+     * @param string $actorInstitution
+     */
+    public function __construct($targetInstitution, $actorInstitution)
+    {
+        $this->targetInstitution = $targetInstitution;
+        $this->actorInstitution = $actorInstitution;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTargetInstitution()
+    {
+        return $this->targetInstitution;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActorInstitution()
+    {
+        return $this->actorInstitution;
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedInOtherInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedInOtherInstitutionVoter.php
@@ -87,13 +87,16 @@ class AllowedInOtherInstitutionVoter implements VoterInterface
         // Now test if any of the roles allow the user to perform the requested task
         foreach ($actorRoles as $role) {
             switch ($role->getRole()) {
+                // The SRAA role is always allowed to perform the VIEW_AUDITLOG action
+                case "ROLE_SRAA":
+                    return VoterInterface::ACCESS_GRANTED;
+                    break;
                 case "ROLE_RA":
                     // RA roles are allowed if the target institution is in the useRa options.
                     if (in_array($subject->getTargetInstitution(), $raInstitutions)) {
                         return VoterInterface::ACCESS_GRANTED;
                     }
                     break;
-                case "ROLE_SRAA":
                 case "ROLE_RAA":
                     // (S)RAA roles are allowed if either the target institution is in the useRa or useRaa options.
                     if (in_array($subject->getTargetInstitution(), array_merge($raInstitutions, $raaInstitutions))) {

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedInOtherInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedInOtherInstitutionVoter.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Voter;
+
+use InvalidArgumentException;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Context\InstitutionContext;
+use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsServiceInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Role\Role;
+
+/**
+ * Given a InstitutionContext, votes if allowed to perform actions on
+ * a target institution (the institution of the identity we are performing actions on).
+ */
+class AllowedInOtherInstitutionVoter implements VoterInterface
+{
+    const VIEW_AUDITLOG = 'view_auditlog';
+
+    private $service;
+
+    public function __construct(InstitutionConfigurationOptionsServiceInterface $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) - many simple tests are required to ascertain if the action is
+     * allowed
+     *
+     * @param TokenInterface $token A TokenInterface instance
+     * @param InstitutionContext $subject The subject to secure
+     * @param array $attributes An array of attributes associated with the method being invoked
+     * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     */
+    public function vote(TokenInterface $token, $subject, array $attributes)
+    {
+        // Check if the class of this object is supported by this voter
+        if (!$this->supportsClass(get_class($subject))) {
+            return VoterInterface::ACCESS_ABSTAIN;
+        }
+
+        // This voter allows one attribute to vote on.
+        if (count($attributes) > 1) {
+            throw new InvalidArgumentException('Only one attribute is allowed');
+        }
+
+        $attribute = $attributes[0];
+
+        // Check if the given attribute is covered by this voter
+        if (!$this->supportsAttribute($attribute)) {
+            return VoterInterface::ACCESS_ABSTAIN;
+        }
+
+        $actorRoles = $token->getRoles();
+
+        // Does the actor have one of the required roles?
+        if (!$this->authorizedByRole($actorRoles)) {
+            return VoterInterface::ACCESS_DENIED;
+        }
+
+        $institutionConfig = $this->service->getInstitutionConfigurationOptionsFor($subject->getActorInstitution());
+
+        if (!$institutionConfig) {
+            return VoterInterface::ACCESS_ABSTAIN;
+        }
+
+        $raInstitutions = $institutionConfig->useRa;
+        $raaInstitutions = $institutionConfig->useRaa;
+
+        // Now test if any of the roles allow the user to perform the requested task
+        foreach ($actorRoles as $role) {
+            switch ($role->getRole()) {
+                case "ROLE_RA":
+                    // RA roles are allowed if the target institution is in the useRa options.
+                    if (in_array($subject->getTargetInstitution(), $raInstitutions)) {
+                        return VoterInterface::ACCESS_GRANTED;
+                    }
+                    break;
+                case "ROLE_SRAA":
+                case "ROLE_RAA":
+                    // (S)RAA roles are allowed if either the target institution is in the useRa or useRaa options.
+                    if (in_array($subject->getTargetInstitution(), array_merge($raInstitutions, $raaInstitutions))) {
+                        return VoterInterface::ACCESS_GRANTED;
+                    }
+                    break;
+            }
+        }
+
+        return VoterInterface::ACCESS_DENIED;
+    }
+
+    private function supportsAttribute($attribute)
+    {
+        return in_array($attribute, [self::VIEW_AUDITLOG]);
+    }
+
+    private function supportsClass($class)
+    {
+        $supportedClass = InstitutionContext::class;
+
+        return $supportedClass === $class;
+    }
+
+    private function authorizedByRole(array $roles)
+    {
+        // The role requirements to VIEW_AUDITLOG, one of these roles must be met
+        $allowedRoles = ['ROLE_SRAA', 'ROLE_RAA', 'ROLE_RA'];
+
+        // Convert the Role[] to an array of strings representing the role names.
+        $roles = array_map(
+            function (Role $role) {
+                return $role->getRole();
+            },
+            $roles
+        );
+
+        // And test if there is an intersection (is one or more of the token roles also in the allowed roles)
+        return count(array_intersect($roles, $allowedRoles)) > 0;
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Service/InstitutionConfigurationOptionsService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/InstitutionConfigurationOptionsService.php
@@ -18,9 +18,10 @@
 
 namespace Surfnet\StepupRa\RaBundle\Service;
 
+use Surfnet\StepupMiddlewareClientBundle\Configuration\Dto\InstitutionConfigurationOptions;
 use Surfnet\StepupMiddlewareClientBundle\Configuration\Service\InstitutionConfigurationOptionsService as ApiInstitutionConfigurationOptionsService;
 
-final class InstitutionConfigurationOptionsService
+final class InstitutionConfigurationOptionsService implements InstitutionConfigurationOptionsServiceInterface
 {
     /**
      * @var ApiInstitutionConfigurationOptionsService
@@ -32,9 +33,28 @@ final class InstitutionConfigurationOptionsService
         $this->apiInstitutionConfigurationOptionsService = $apiService;
     }
 
+    /**
+     * @param $institution
+     * @return null|InstitutionConfigurationOptions
+     */
     public function getInstitutionConfigurationOptionsFor($institution)
     {
-        return $this->apiInstitutionConfigurationOptionsService->getInstitutionConfigurationOptionsFor($institution);
+        $configuration = $this->apiInstitutionConfigurationOptionsService->getInstitutionConfigurationOptionsFor($institution);
+
+        // If the FGA options are null (which they may be) then set them with the default value. This is the own institution.
+        if (is_null($configuration->useRa)) {
+            $configuration->useRa = [$institution];
+        }
+
+        if (is_null($configuration->useRaa)) {
+            $configuration->useRaa = [$institution];
+        }
+
+        if (is_null($configuration->selectRaa)) {
+            $configuration->selectRaa = [$institution];
+        }
+
+        return $configuration;
     }
 
     /**

--- a/src/Surfnet/StepupRa/RaBundle/Service/InstitutionConfigurationOptionsServiceInterface.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/InstitutionConfigurationOptionsServiceInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+* Copyright 2018 SURFnet B.V.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Surfnet\StepupMiddlewareClientBundle\Configuration\Dto\InstitutionConfigurationOptions;
+
+interface InstitutionConfigurationOptionsServiceInterface
+{
+    /**
+     * @param $institution
+     * @return null|InstitutionConfigurationOptions
+     */
+    public function getInstitutionConfigurationOptionsFor($institution);
+
+    /**
+     * Return the institutions that are configured in the useRa and useRaa insititution
+     * configuration options.
+     *
+     * If one of the two configuration options is configured with null (the default),
+     * than the institution the query was performed for is set as the default.
+     *
+     * @param $institution
+     * @return array
+     */
+    public function getAvailableInstitutionsFor($institution);
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
@@ -158,12 +158,6 @@ class AllowedInOtherInstitutionVoterTest extends TestCase
                 $this->getOptions(['ra' => [], 'raa' => []]),
                 $this->getContext('a', 'b'),
             ],
-            'no-ample-institution-config-options-available-even-for-sraa' => [
-                VoterInterface::ACCESS_DENIED,
-                $this->getRoles(['ROLE_SRAA']),
-                $this->getOptions(['ra' => [], 'raa' => []]),
-                $this->getContext('a', 'b'),
-            ],
             'not-configured-target-institution' => [
                 VoterInterface::ACCESS_DENIED,
                 $this->getRoles(['ROLE_RA']),

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Voter;
+
+use Mockery as m;
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupMiddlewareClientBundle\Configuration\Dto\InstitutionConfigurationOptions;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Context\InstitutionContext;
+use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsServiceInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Role\Role;
+
+class AllowedInOtherInstitutionVoterTest extends TestCase
+{
+    /**
+     * @test
+     * @group security
+     * @dataProvider scenarios
+     */
+    public function test_view_audit_log(
+        $expectation,
+        array $actorRoles,
+        $options,
+        $institutionContext,
+        $action = null
+    )
+    {
+        $service = m::mock(InstitutionConfigurationOptionsServiceInterface::class);
+        $voter = new AllowedInOtherInstitutionVoter($service);
+
+        $token = m::mock(SamlToken::class);
+
+        $token
+            ->shouldReceive('getRoles')
+            ->once()
+            ->andReturn($actorRoles);
+
+        if ($institutionContext instanceof InstitutionContext) {
+            $service
+                ->shouldReceive('getInstitutionConfigurationOptionsFor')
+                ->with($institutionContext->getActorInstitution())
+                ->andReturn($options);
+        }
+
+        $attributes = [AllowedInOtherInstitutionVoter::VIEW_AUDITLOG];
+        if ($action) {
+            $attributes = $action;
+        }
+
+        $this->assertEquals(
+            $expectation,
+            $voter->vote($token, $institutionContext, $attributes)
+        );
+    }
+
+    /**
+     * @test
+     * @group security
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_considers_the_passing_of_multiple_attributes_as_invalid_input()
+    {
+        $service = m::mock(InstitutionConfigurationOptionsServiceInterface::class);
+        $voter = new AllowedInOtherInstitutionVoter($service);
+        $user = m::mock(AbstractToken::class);
+        $token = m::mock(SamlToken::class);
+
+        $user
+            ->shouldReceive('getRoles')
+            ->once()
+            ->andReturn(['ROLE_RAA']);
+
+        $token
+            ->shouldReceive('getUser')
+            ->once()
+            ->andReturn($user);
+
+        $voter->vote($token, new InstitutionContext('a', 'b'), [AllowedInOtherInstitutionVoter::VIEW_AUDITLOG, 'arbitrary-attribute']);
+    }
+
+    public function scenarios()
+    {
+        return array_merge($this->granted(), $this->denied(), $this->abstain());
+    }
+
+    private function granted()
+    {
+        return [
+            'ra-views-auditlog-of-another-institution' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RA']),
+                $this->getOptions(['ra' => ['a', 'b'], 'raa' => []]),
+                $this->getContext('a', 'b'),
+            ],
+            'ra-views-auditlog-of-another-institution-extra-role' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RA', 'ROLE_USER']),
+                $this->getOptions(['ra' => ['a', 'b'], 'raa' => []]),
+                $this->getContext('a', 'b'),
+            ],
+            'raa-views-auditlog-of-another-institution' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RAA']),
+                $this->getOptions(['ra' => ['a', 'b'], 'raa' => []]),
+                $this->getContext('a', 'b'),
+            ],
+            'raa-views-auditlog-of-another-institution-only-raa' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RAA']),
+                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
+                $this->getContext('a', 'b'),
+            ],
+            'sraa-views-auditlog-of-another-institution' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_SRAA']),
+                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
+                $this->getContext('a', 'b'),
+            ],
+            'ra-views-auditlog-of-same-institution' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RA']),
+                $this->getOptions(['ra' => ['a', 'b'], 'raa' => []]),
+                $this->getContext('a', 'a'),
+            ],
+        ];
+    }
+
+    private  function denied()
+    {
+        return [
+            'only-raas-are-granted-access' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_RA']),
+                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
+                $this->getContext('a', 'b'),
+            ],
+            'no-ample-institution-config-options-available' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_RA']),
+                $this->getOptions(['ra' => [], 'raa' => []]),
+                $this->getContext('a', 'b'),
+            ],
+            'no-ample-institution-config-options-available-even-for-sraa' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_SRAA']),
+                $this->getOptions(['ra' => [], 'raa' => []]),
+                $this->getContext('a', 'b'),
+            ],
+            'not-configured-target-institution' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_RA']),
+                $this->getOptions(['ra' => ['a'], 'raa' => []]),
+                $this->getContext('a', 'b'),
+            ],
+            'invalid-role' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_ARA']),
+                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
+                $this->getContext('a', 'b'),
+            ],
+        ];
+    }
+
+    private  function abstain()
+    {
+        return [
+            'unsupported-attribute' => [
+                VoterInterface::ACCESS_ABSTAIN,
+                $this->getRoles(['ROLE_RAA']),
+                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
+                $this->getContext('a', 'b'),
+                ['read']
+            ],
+            'missing-institution-config' => [
+                VoterInterface::ACCESS_ABSTAIN,
+                $this->getRoles(['ROLE_RA']),
+                null,
+                $this->getContext('a', 'b'),
+            ],
+            'invalid-context' => [
+                VoterInterface::ACCESS_ABSTAIN,
+                $this->getRoles(['ROLE_RA']),
+                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
+                new \stdClass()
+            ],
+        ];
+    }
+
+    private function getOptions($configuration)
+    {
+        $options = new InstitutionConfigurationOptions();
+        $options->useRa = $configuration['ra'];
+        $options->useRaa = $configuration['raa'];
+        return $options;
+    }
+
+    private function getContext($actorInstitution, $targetInstitution)
+    {
+        return new InstitutionContext($targetInstitution, $actorInstitution);
+    }
+
+    private function getRoles(array $rawRoles)
+    {
+        $roles = [];
+        foreach ($rawRoles as $role){
+            $roles[] = new Role($role);
+        }
+        return $roles;
+    }
+}


### PR DESCRIPTION
The voter for now only tests if the logged in user is allowed to
VIEW_AUDITLOG. Other authorizations can be added to this voter if the
context is 'allowed in other institutions'.

The vote method body might need to be revised at that point. But for
now this tests all the appropriate authorization related checks.