### PR TITLE
Pass the actor id when starting vetting procedure

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -70,7 +70,7 @@ class VettingController extends Controller
         }
 
         $secondFactor = $this->getSecondFactorService()
-            ->findVerifiedSecondFactorByRegistrationCode($command->registrationCode, $identity->institution);
+            ->findVerifiedSecondFactorByRegistrationCode($command->registrationCode, $identity->institution, $identity->id);
 
         if ($secondFactor === null) {
             $this->addFlash('error', 'ra.form.start_vetting_procedure.unknown_registration_code');

--- a/src/Surfnet/StepupRa/RaBundle/Service/SecondFactorService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/SecondFactorService.php
@@ -52,12 +52,14 @@ class SecondFactorService
     /**
      * @param string $registrationCode
      * @param string $actorInstitution
+     * @param string $actorId
      * @return null|VerifiedSecondFactor
      */
-    public function findVerifiedSecondFactorByRegistrationCode($registrationCode, $actorInstitution)
+    public function findVerifiedSecondFactorByRegistrationCode($registrationCode, $actorInstitution, $actorId)
     {
         $query = new VerifiedSecondFactorSearchQuery();
         $query->setActorInstitution($actorInstitution);
+        $query->setActorId($actorId);
         $query->setRegistrationCode($registrationCode);
 
         try {


### PR DESCRIPTION
The actor id is used to test in MW, if the actor is a SRAA. If the user
is SRAA, then it is allowed to vet tokens of any institution. If the
user is not SRAA, then FGA options are taken into account.

For now this additional SRAA context is required when starting the
vetting procedure.

See https://www.pivotaltracker.com/story/show/160283514