### PR TITLE
Add the RAA institution switcher

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-10-25T14:09:34Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-10-30T16:37:26Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -20,7 +20,7 @@
       <trans-unit id="5f1e0c5b2426bfd27630e1a79ced536d4ef05d10" resname="footer.documentation">
         <source>footer.documentation</source>
         <target>Manual</target>
-        <jms:reference-file line="99">/Resources/views/base.html.twig</jms:reference-file>
+        <jms:reference-file line="107">/Resources/views/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a08764057e3607049e3495943676b29f7baefba9" resname="locale.en_GB">
         <source>locale.en_GB</source>
@@ -211,17 +211,12 @@
       <trans-unit id="2ddc6712364551204f635e4718e015e682fd208c" resname="ra.form.ra_search_ra_candidates.button.search">
         <source>ra.form.ra_search_ra_candidates.button.search</source>
         <target>Search</target>
-        <jms:reference-file line="41">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
+        <jms:reference-file line="38">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="543a02dfd360a01fa0c9076da584e3f8d69394b4" resname="ra.form.ra_search_ra_candidates.label.email">
         <source>ra.form.ra_search_ra_candidates.label.email</source>
         <target>E-mail</target>
         <jms:reference-file line="35">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="5349450b9c65b0e168b1468704c538dfbcddf6a9" resname="ra.form.ra_search_ra_candidates.label.institution">
-        <source>ra.form.ra_search_ra_candidates.label.institution</source>
-        <target state="new">ra.form.ra_search_ra_candidates.label.institution</target>
-        <jms:reference-file line="38">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9f4c34138ef487cdf008770c1257b06291343831" resname="ra.form.ra_search_ra_candidates.label.name">
         <source>ra.form.ra_search_ra_candidates.label.name</source>
@@ -303,11 +298,13 @@
         <source>ra.form.ra_select_institution.button.select_and_apply</source>
         <target>Save</target>
         <jms:reference-file line="46">/../src/Surfnet/StepupRa/RaBundle/Form/Type/InstitutionSelectionType.php</jms:reference-file>
+        <jms:reference-file line="44">/../src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aff72bc7d94c65f8b3dcf0b3b9bb3f5430ac28f6" resname="ra.form.ra_select_institution.label.institution">
         <source>ra.form.ra_select_institution.label.institution</source>
         <target>Institution</target>
         <jms:reference-file line="43">/../src/Surfnet/StepupRa/RaBundle/Form/Type/InstitutionSelectionType.php</jms:reference-file>
+        <jms:reference-file line="37">/../src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b190a055ec0458747cdff543e6693c2433a6eb6b" resname="ra.form.ra_send_sms_challenge.button.send_challenge">
         <source>ra.form.ra_send_sms_challenge.button.send_challenge</source>
@@ -378,7 +375,7 @@
       <trans-unit id="5fa5dfb0514d509432e81f5b2344b12d7351715b" resname="ra.management.amend_ra_info.info_amended">
         <source>ra.management.amend_ra_info.info_amended</source>
         <target>The RA's information has been amended.</target>
-        <jms:reference-file line="245">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="249">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6492fd6bfd9bf1c89d052b3172d572e9df9e54e8" resname="ra.management.amend_ra_info.ra_listing.email">
         <source>ra.management.amend_ra_info.ra_listing.email</source>
@@ -456,7 +453,7 @@
       <trans-unit id="011f64144e98b72e6a4ec42919ceb12298f059ef" resname="ra.management.change_ra_role_changed">
         <source>ra.management.change_ra_role_changed</source>
         <target>The Registration Authority has been granted the selected role</target>
-        <jms:reference-file line="291">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="296">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f2d212150076ce42ffe47d514f182ad5e7a6c9fe" resname="ra.management.create_ra.error.middleware_command_failed">
         <source>ra.management.create_ra.error.middleware_command_failed</source>
@@ -466,7 +463,7 @@
       <trans-unit id="4029e4383ef4a57077b346cc66f971c9cafb71c3" resname="ra.management.create_ra.identity_accredited">
         <source>ra.management.create_ra.identity_accredited</source>
         <target>The role of this user has been changed.</target>
-        <jms:reference-file line="199">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="201">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="62bc099c53662e393741f519a15503dcb4d6c77f" resname="ra.management.create_ra.modal.are_you_sure">
         <source>ra.management.create_ra.modal.are_you_sure</source>
@@ -570,7 +567,7 @@
       <trans-unit id="6940fb31b4ca7388731a323d43c673c20895ddad" resname="ra.management.form.change_ra_management_institution.label.submit">
         <source>ra.management.form.change_ra_management_institution.label.submit</source>
         <target>Save</target>
-        <jms:reference-file line="42">/../src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaManagementInstitutionType.php</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaManagementInstitutionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c46b2115a26b03ef1c8eb69d299b537486003056" resname="ra.management.form.change_ra_role.label.role">
         <source>ra.management.form.change_ra_role.label.role</source>
@@ -613,36 +610,31 @@
         <target>Add RA(A)</target>
         <jms:reference-file line="7">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="65486b5669de95b6a49203f59af122ec56fdc5ba" resname="ra.management.overview.change_role">
-        <source>ra.management.overview.change_role</source>
-        <target>Change Role</target>
-        <jms:reference-file line="33">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="249a6c69487c5477929e1dac383aa2d02fb25198" resname="ra.management.overview.common_name">
         <source>ra.management.overview.common_name</source>
         <target>Name</target>
-        <jms:reference-file line="13">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
         <jms:reference-file line="26">/../src/Surfnet/StepupRa/RaBundle/Resources/views/Vetting/verifyIdentity.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f702b148afefffede0240eb3d7e4d4d902c23255" resname="ra.management.overview.email">
         <source>ra.management.overview.email</source>
         <target>E-mail</target>
-        <jms:reference-file line="14">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="44ed8664990fcd8d55324dc98bfa3ac905bb9c0d" resname="ra.management.overview.institution">
         <source>ra.management.overview.institution</source>
         <target>Institution</target>
-        <jms:reference-file line="15">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6f5ea2d06110a1b436b1814e53f99aeae92c867" resname="ra.management.overview.remove_as_ra">
         <source>ra.management.overview.remove_as_ra</source>
         <target>Remove role</target>
-        <jms:reference-file line="39">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3405f2d5ec00142a5b1b5c0c1509b6aa2543473b" resname="ra.management.overview.role">
         <source>ra.management.overview.role</source>
         <target>Role</target>
-        <jms:reference-file line="16">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="23">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="64d8691325da6d2b996fd48f7da7a382fdeb22e7" resname="ra.management.overview.role.value.ra">
         <source>ra.management.overview.role.value.ra</source>
@@ -662,7 +654,7 @@
       <trans-unit id="3d101556c7d65068f5e964ba8c5a9b8709e23266" resname="ra.management.overview.update_information">
         <source>ra.management.overview.update_information</source>
         <target>Edit</target>
-        <jms:reference-file line="36">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="114a1fc30fec7da3d1a7dc2b9a55d2b5dd78c8ce" resname="ra.management.ra_candidate.common_name">
         <source>ra.management.ra_candidate.common_name</source>
@@ -702,7 +694,7 @@
       <trans-unit id="1a03ce1515132785c884129598c2cb52db461cd0" resname="ra.management.retract_ra.success">
         <source>ra.management.retract_ra.success</source>
         <target>The Identity is no longer RA(A)</target>
-        <jms:reference-file line="338">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="344">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a973963d22345656dc73a28876fe2a9e481c6d3a" resname="ra.management.retract_registration_authority.are_you_sure">
         <source>ra.management.retract_registration_authority.are_you_sure</source>
@@ -733,6 +725,7 @@
         <source>ra.menu.sraa_change_institution</source>
         <target>change</target>
         <jms:reference-file line="66">/Resources/views/base.html.twig</jms:reference-file>
+        <jms:reference-file line="74">/Resources/views/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ff49fbf3684f01850a026abeff8b6f3cd6d89a98" resname="ra.prove_phone_possession.challenge_expired">
         <source>ra.prove_phone_possession.challenge_expired</source>
@@ -1034,6 +1027,7 @@
       <trans-unit id="e8ada95651cf644c6bbeeff32c330b4fde42f87d" resname="ra.sraa.changed_institution">
         <source>ra.sraa.changed_institution</source>
         <target>Your institution has been changed to "%institution%"</target>
+        <jms:reference-file line="63">/../src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php</jms:reference-file>
         <jms:reference-file line="54">/../src/Surfnet/StepupRa/RaBundle/Controller/SraaController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-10-25T14:09:30Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-10-30T16:37:20Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -20,7 +20,7 @@
       <trans-unit id="5f1e0c5b2426bfd27630e1a79ced536d4ef05d10" resname="footer.documentation">
         <source>footer.documentation</source>
         <target>Handleiding</target>
-        <jms:reference-file line="99">/Resources/views/base.html.twig</jms:reference-file>
+        <jms:reference-file line="107">/Resources/views/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a08764057e3607049e3495943676b29f7baefba9" resname="locale.en_GB">
         <source>locale.en_GB</source>
@@ -211,17 +211,12 @@
       <trans-unit id="2ddc6712364551204f635e4718e015e682fd208c" resname="ra.form.ra_search_ra_candidates.button.search">
         <source>ra.form.ra_search_ra_candidates.button.search</source>
         <target>Zoeken</target>
-        <jms:reference-file line="41">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
+        <jms:reference-file line="38">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="543a02dfd360a01fa0c9076da584e3f8d69394b4" resname="ra.form.ra_search_ra_candidates.label.email">
         <source>ra.form.ra_search_ra_candidates.label.email</source>
         <target>E-mail</target>
         <jms:reference-file line="35">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="5349450b9c65b0e168b1468704c538dfbcddf6a9" resname="ra.form.ra_search_ra_candidates.label.institution">
-        <source>ra.form.ra_search_ra_candidates.label.institution</source>
-        <target state="new">ra.form.ra_search_ra_candidates.label.institution</target>
-        <jms:reference-file line="38">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9f4c34138ef487cdf008770c1257b06291343831" resname="ra.form.ra_search_ra_candidates.label.name">
         <source>ra.form.ra_search_ra_candidates.label.name</source>
@@ -303,11 +298,13 @@
         <source>ra.form.ra_select_institution.button.select_and_apply</source>
         <target>Opslaan</target>
         <jms:reference-file line="46">/../src/Surfnet/StepupRa/RaBundle/Form/Type/InstitutionSelectionType.php</jms:reference-file>
+        <jms:reference-file line="44">/../src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aff72bc7d94c65f8b3dcf0b3b9bb3f5430ac28f6" resname="ra.form.ra_select_institution.label.institution">
         <source>ra.form.ra_select_institution.label.institution</source>
         <target>Instituut</target>
         <jms:reference-file line="43">/../src/Surfnet/StepupRa/RaBundle/Form/Type/InstitutionSelectionType.php</jms:reference-file>
+        <jms:reference-file line="37">/../src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b190a055ec0458747cdff543e6693c2433a6eb6b" resname="ra.form.ra_send_sms_challenge.button.send_challenge">
         <source>ra.form.ra_send_sms_challenge.button.send_challenge</source>
@@ -378,7 +375,7 @@
       <trans-unit id="5fa5dfb0514d509432e81f5b2344b12d7351715b" resname="ra.management.amend_ra_info.info_amended">
         <source>ra.management.amend_ra_info.info_amended</source>
         <target>De informatie van de RA is gewijzigd.</target>
-        <jms:reference-file line="245">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="249">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6492fd6bfd9bf1c89d052b3172d572e9df9e54e8" resname="ra.management.amend_ra_info.ra_listing.email">
         <source>ra.management.amend_ra_info.ra_listing.email</source>
@@ -456,7 +453,7 @@
       <trans-unit id="011f64144e98b72e6a4ec42919ceb12298f059ef" resname="ra.management.change_ra_role_changed">
         <source>ra.management.change_ra_role_changed</source>
         <target>De Registratie Authoriteit heeft de gekozen rol toegewezen gekregen</target>
-        <jms:reference-file line="291">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="296">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f2d212150076ce42ffe47d514f182ad5e7a6c9fe" resname="ra.management.create_ra.error.middleware_command_failed">
         <source>ra.management.create_ra.error.middleware_command_failed</source>
@@ -466,7 +463,7 @@
       <trans-unit id="4029e4383ef4a57077b346cc66f971c9cafb71c3" resname="ra.management.create_ra.identity_accredited">
         <source>ra.management.create_ra.identity_accredited</source>
         <target>De rol van deze gebruiker is gewijzigd.</target>
-        <jms:reference-file line="199">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="201">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="62bc099c53662e393741f519a15503dcb4d6c77f" resname="ra.management.create_ra.modal.are_you_sure">
         <source>ra.management.create_ra.modal.are_you_sure</source>
@@ -570,7 +567,7 @@
       <trans-unit id="6940fb31b4ca7388731a323d43c673c20895ddad" resname="ra.management.form.change_ra_management_institution.label.submit">
         <source>ra.management.form.change_ra_management_institution.label.submit</source>
         <target>Opslaan</target>
-        <jms:reference-file line="42">/../src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaManagementInstitutionType.php</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaManagementInstitutionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c46b2115a26b03ef1c8eb69d299b537486003056" resname="ra.management.form.change_ra_role.label.role">
         <source>ra.management.form.change_ra_role.label.role</source>
@@ -613,36 +610,31 @@
         <target>Voeg RA(A) toe</target>
         <jms:reference-file line="7">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="65486b5669de95b6a49203f59af122ec56fdc5ba" resname="ra.management.overview.change_role">
-        <source>ra.management.overview.change_role</source>
-        <target>Verander Rol</target>
-        <jms:reference-file line="33">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="249a6c69487c5477929e1dac383aa2d02fb25198" resname="ra.management.overview.common_name">
         <source>ra.management.overview.common_name</source>
         <target>Naam</target>
-        <jms:reference-file line="13">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
         <jms:reference-file line="26">/../src/Surfnet/StepupRa/RaBundle/Resources/views/Vetting/verifyIdentity.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f702b148afefffede0240eb3d7e4d4d902c23255" resname="ra.management.overview.email">
         <source>ra.management.overview.email</source>
         <target>E-mail</target>
-        <jms:reference-file line="14">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="44ed8664990fcd8d55324dc98bfa3ac905bb9c0d" resname="ra.management.overview.institution">
         <source>ra.management.overview.institution</source>
         <target>Instituut</target>
-        <jms:reference-file line="15">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6f5ea2d06110a1b436b1814e53f99aeae92c867" resname="ra.management.overview.remove_as_ra">
         <source>ra.management.overview.remove_as_ra</source>
         <target>Verwijder rol</target>
-        <jms:reference-file line="39">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="43">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3405f2d5ec00142a5b1b5c0c1509b6aa2543473b" resname="ra.management.overview.role">
         <source>ra.management.overview.role</source>
         <target>Rol</target>
-        <jms:reference-file line="16">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="23">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="64d8691325da6d2b996fd48f7da7a382fdeb22e7" resname="ra.management.overview.role.value.ra">
         <source>ra.management.overview.role.value.ra</source>
@@ -662,7 +654,7 @@
       <trans-unit id="3d101556c7d65068f5e964ba8c5a9b8709e23266" resname="ra.management.overview.update_information">
         <source>ra.management.overview.update_information</source>
         <target>Wijzig</target>
-        <jms:reference-file line="36">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="114a1fc30fec7da3d1a7dc2b9a55d2b5dd78c8ce" resname="ra.management.ra_candidate.common_name">
         <source>ra.management.ra_candidate.common_name</source>
@@ -702,7 +694,7 @@
       <trans-unit id="1a03ce1515132785c884129598c2cb52db461cd0" resname="ra.management.retract_ra.success">
         <source>ra.management.retract_ra.success</source>
         <target>De Identiteit is geen RA(A) meer</target>
-        <jms:reference-file line="338">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
+        <jms:reference-file line="344">/../src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a973963d22345656dc73a28876fe2a9e481c6d3a" resname="ra.management.retract_registration_authority.are_you_sure">
         <source>ra.management.retract_registration_authority.are_you_sure</source>
@@ -733,6 +725,7 @@
         <source>ra.menu.sraa_change_institution</source>
         <target>verander</target>
         <jms:reference-file line="66">/Resources/views/base.html.twig</jms:reference-file>
+        <jms:reference-file line="74">/Resources/views/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ff49fbf3684f01850a026abeff8b6f3cd6d89a98" resname="ra.prove_phone_possession.challenge_expired">
         <source>ra.prove_phone_possession.challenge_expired</source>
@@ -1034,6 +1027,7 @@
       <trans-unit id="e8ada95651cf644c6bbeeff32c330b4fde42f87d" resname="ra.sraa.changed_institution">
         <source>ra.sraa.changed_institution</source>
         <target>Je instituut is veranderd naar "%institution%"</target>
+        <jms:reference-file line="63">/../src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php</jms:reference-file>
         <jms:reference-file line="54">/../src/Surfnet/StepupRa/RaBundle/Controller/SraaController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="abe2e824031a2393db11918365a49cf65d3ec585" resname="ra.verify_identity.identity_verification_failed">

--- a/app/Resources/translations/validators.en_GB.xliff
+++ b/app/Resources/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-10-25T14:09:34Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2018-10-30T16:37:26Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/validators.nl_NL.xliff
+++ b/app/Resources/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-10-25T14:09:30Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2018-10-30T16:37:20Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -67,6 +67,15 @@
                             </a>
                         </li>
                     </ul>
+                {# TODO  Use a voter to determine if the switcher should be displayed (if only RAA for one institution, then there is no use to show the switcher) #}
+                {% elseif is_granted('ROLE_RAA') %}
+                    <ul class="nav nav-pills pull-right">
+                        <li role="presentation"{% if app.request.attributes.get('_route') == 'raa_select_institution' %} class="active"{% endif %}>
+                            <a href="{{ path('raa_select_institution') }}">
+                                {{ app.user.institution }} <i class="fa fa-exchange"></i> {{ 'ra.menu.sraa_change_institution'|trans }}
+                            </a>
+                        </li>
+                    </ul>
                 {% endif %}
                 </div>
             </div>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -67,8 +67,7 @@
                             </a>
                         </li>
                     </ul>
-                {# TODO  Use a voter to determine if the switcher should be displayed (if only RAA for one institution, then there is no use to show the switcher) #}
-                {% elseif is_granted('ROLE_RAA') %}
+                {% elseif is_granted('raa_switching') %}
                     <ul class="nav nav-pills pull-right">
                         <li role="presentation"{% if app.request.attributes.get('_route') == 'raa_select_institution' %} class="active"{% endif %}>
                             <a href="{{ path('raa_select_institution') }}">

--- a/src/Surfnet/StepupRa/RaBundle/Command/ChangeRaaInstitutionCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/ChangeRaaInstitutionCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Command;
+
+class ChangeRaaInstitutionCommand
+{
+    /**
+     * @var string
+     */
+    public $institution;
+
+    /**
+     * @var array
+     */
+    public $availableInstitutions = [];
+}

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Controller;
+
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Surfnet\StepupRa\RaBundle\Command\ChangeRaaInstitutionCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\RaaInstitutionSelectionType;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
+use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class RaaController extends Controller
+{
+    public function selectInstitutionAction(Request $request)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_RAA']);
+
+        /** @var SamlToken $token */
+        $token  = $this->get('security.token_storage')->getToken();
+        $logger = $this->get('logger');
+
+        /** @var Identity $identity */
+        $identity = $token->getUser();
+        $institution = $identity->institution;
+
+        $logger->notice(sprintf('Select Institution for RAA "%s"', $identity->id));
+
+        $raaSwitcherOptions = $this
+            ->getInstitutionConfigurationOptionsService()
+            ->getAvailableInstitutionsFor($token->getIdentityInstitution());
+
+        $command = new ChangeRaaInstitutionCommand();
+        $command->institution = $institution;
+        $command->availableInstitutions = $raaSwitcherOptions;
+
+        $form = $this->createForm(RaaInstitutionSelectionType::class, $command);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $institutionConfigurationOptions = $this->getInstitutionConfigurationOptionsService()
+                ->getInstitutionConfigurationOptionsFor($command->institution);
+            $token->changeInstitutionScope($command->institution, $institutionConfigurationOptions);
+
+            $flashMessage = $this->get('translator')
+                ->trans('ra.sraa.changed_institution', ['%institution%' => $command->institution]);
+            $this->get('session')->getFlashBag()->add('success', $flashMessage);
+
+            $logger->notice(sprintf(
+                'RAA "%s" successfully switched to institution "%s"',
+                $identity->id,
+                $command->institution
+            ));
+
+            return $this->redirect($this->generateUrl('ra_vetting_search'));
+        }
+
+        $logger->notice(sprintf('Showing select institution form for RAA "%s"', $identity->id));
+
+        return $this->render(
+            // Reuse the SRAA switcher twig template
+            'SurfnetStepupRaRaBundle:Sraa:selectInstitution.html.twig',
+            ['form' => $form->createView()]
+        );
+    }
+
+
+    /**
+     * @return InstitutionConfigurationOptionsService
+     */
+    private function getInstitutionConfigurationOptionsService()
+    {
+        return $this->get('ra.service.institution_configuration_options');
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
@@ -22,6 +22,7 @@ use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
 use Surfnet\StepupRa\RaBundle\Command\ChangeRaaInstitutionCommand;
 use Surfnet\StepupRa\RaBundle\Form\Type\RaaInstitutionSelectionType;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter;
 use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,7 +31,7 @@ class RaaController extends Controller
 {
     public function selectInstitutionAction(Request $request)
     {
-        $this->denyAccessUnlessGranted(['ROLE_RAA']);
+        $this->denyAccessUnlessGranted([AllowedToSwitchInstitutionVoter::RAA_SWITCHING]);
 
         /** @var SamlToken $token */
         $token  = $this->get('security.token_storage')->getToken();

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
@@ -24,6 +24,7 @@ use Surfnet\StepupRa\RaBundle\Form\Type\RaaInstitutionSelectionType;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter;
 use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
+use Surfnet\StepupRa\RaBundle\Service\RaListingService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -44,8 +45,8 @@ class RaaController extends Controller
         $logger->notice(sprintf('Select Institution for RAA "%s"', $identity->id));
 
         $raaSwitcherOptions = $this
-            ->getInstitutionConfigurationOptionsService()
-            ->getAvailableInstitutionsFor($token->getIdentityInstitution());
+            ->getRaListingService()
+            ->createChoiceListFor($token->getIdentityInstitution());
 
         $command = new ChangeRaaInstitutionCommand();
         $command->institution = $institution;
@@ -81,6 +82,13 @@ class RaaController extends Controller
         );
     }
 
+    /**
+     * @return RaListingService
+     */
+    private function getRaListingService()
+    {
+        return $this->get('ra.service.ra_listing');
+    }
 
     /**
      * @return InstitutionConfigurationOptionsService

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Form\Type;
+
+use Surfnet\StepupRa\RaBundle\Command\ChangeRaaInstitutionCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RaaInstitutionSelectionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $options = array_combine(
+            $builder->getData()->availableInstitutions,
+            $builder->getData()->availableInstitutions
+        );
+
+        $builder
+            ->add(
+                'institution',
+                ChoiceType::class,
+                [
+                    'label' => 'ra.form.ra_select_institution.label.institution',
+                    'choices' => $options,
+                ]
+            )->add(
+                'select_and_apply',
+                SubmitType::class,
+                [
+                    'label' => 'ra.form.ra_select_institution.button.select_and_apply',
+                    'attr' => ['class' => 'btn btn-primary pull-right'],
+                ]
+            );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => ChangeRaaInstitutionCommand::class,
+            ]
+        );
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'raa_institution_select';
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RaaInstitutionSelectionType.php
@@ -29,18 +29,13 @@ class RaaInstitutionSelectionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $options = array_combine(
-            $builder->getData()->availableInstitutions,
-            $builder->getData()->availableInstitutions
-        );
-
         $builder
             ->add(
                 'institution',
                 ChoiceType::class,
                 [
                     'label' => 'ra.form.ra_select_institution.label.institution',
-                    'choices' => $options,
+                    'choices' => $builder->getData()->availableInstitutions,
                 ]
             )->add(
                 'select_and_apply',

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
@@ -148,6 +148,11 @@ sraa_select_institution:
     methods:  [GET, POST]
     defaults: { _controller: SurfnetStepupRaRaBundle:Sraa:selectInstitution }
 
+raa_select_institution:
+    path:     /raa/select-institution
+    methods:  [GET, POST]
+    defaults: { _controller: SurfnetStepupRaRaBundle:Raa:selectInstitution }
+
 ra_switch_locale:
     path:     /switch-locale
     methods:  [POST]

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
@@ -126,7 +126,7 @@ services:
     ra.security.authorization.allowed_to_switch_institution:
         class: Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter
         arguments:
-            - '@surfnet_stepup_middleware_client.library.identity.service.ra_listing'
+            - '@ra.service.ra_listing'
         tags:
             - { name: security.voter }
         public: false

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
@@ -122,3 +122,12 @@ services:
         tags:
             - { name: security.voter }
         public: false
+
+    ra.security.authorization.allowed_to_switch_institution:
+        class: Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter
+        arguments:
+            - '@surfnet_stepup_middleware_client.library.identity.service.ra_listing'
+        tags:
+            - { name: security.voter }
+        public: false
+

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -249,6 +249,12 @@ services:
             - "%locales%"
             - "%support_url%"
 
+    ra.service.ra_listing:
+        class: Surfnet\StepupRa\RaBundle\Service\RaListingService
+        arguments:
+            - '@surfnet_stepup_middleware_client.identity.service.ra_listing'
+            - '@logger'
+
     # Repositories
     ra.repository.vetting_procedure:
         class: Surfnet\StepupRa\RaBundle\Repository\SessionVettingProcedureRepository

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -70,6 +70,10 @@ services:
             - "@ra.form.extension.institution_listing_choice_list"
         tags: [{ name: form.type, alias: sraa_institution_select }]
 
+    ra.form.type.raa_institution_select:
+        class: Surfnet\StepupRa\RaBundle\Form\Type\RaaInstitutionSelectionType
+        tags: [{ name: form.type, alias: raa_institution_select }]
+
     ra.form.type.management.create_ra:
         class: Surfnet\StepupRa\RaBundle\Form\Type\CreateRaType
         tags: [{ name: form.type, alias: ra_management_create_ra }]

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Voter;
+
+use InvalidArgumentException;
+use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Role\Role;
+
+/**
+ * Votes whether or not a RAA user is allowed to see the institution switcher
+ *
+ * The ROLE_RAA is allowed to switch institutions when (s)he is:
+ *  - is RAA
+ *  - for more than one institution
+ */
+class AllowedToSwitchInstitutionVoter implements VoterInterface
+{
+    const RAA_SWITCHING = 'raa_switching';
+
+    /**
+     * @var RaListingService
+     */
+    private $service;
+
+    public function __construct(RaListingService $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @param TokenInterface $token A TokenInterface instance
+     * @param $subject not used
+     * @param array $attributes contains the subject (triggered from twig is_granted function)
+     * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     */
+    public function vote(TokenInterface $token, $subject, array $attributes)
+    {
+        // Check if the class of this object is supported by this voter
+        if (!$this->supportsAttribute(reset($attributes))) {
+            return VoterInterface::ACCESS_ABSTAIN;
+        }
+
+        // This voter allows one attribute to vote on.
+        if (count($attributes) > 1) {
+            throw new InvalidArgumentException('Only one attribute is allowed');
+        }
+
+        $actorRoles = $token->getRoles();
+
+        // Does the actor have one of the required roles?
+        if (!$this->authorizedByRole($actorRoles)) {
+            return VoterInterface::ACCESS_DENIED;
+        }
+
+        $query = new RaListingSearchQuery($token->getIdentityInstitution(), 1);
+        $query->setIdentityId($token->getIdentityInstitution());
+        $raListing = $this->service->search($query);
+
+        if ($raListing->getTotalItems() > 1) {
+            return VoterInterface::ACCESS_GRANTED;
+        }
+
+        return VoterInterface::ACCESS_DENIED;
+    }
+
+    private function supportsAttribute($attribute)
+    {
+        return in_array($attribute, [self::RAA_SWITCHING]);
+    }
+
+    private function authorizedByRole(array $roles)
+    {
+        $allowedRoles = ['ROLE_SRAA', 'ROLE_RAA'];
+
+        // Convert the Role[] to an array of strings representing the role names.
+        $roles = array_map(
+            function (Role $role) {
+                return $role->getRole();
+            },
+            $roles
+        );
+
+        // And test if there is an intersection (is one or more of the token roles also in the allowed roles)
+        return count(array_intersect($roles, $allowedRoles)) > 0;
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
@@ -19,8 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Voter;
 
 use InvalidArgumentException;
-use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService;
+use Surfnet\StepupRa\RaBundle\Service\RaListingService;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Role\Role;
@@ -71,9 +70,7 @@ class AllowedToSwitchInstitutionVoter implements VoterInterface
             return VoterInterface::ACCESS_DENIED;
         }
 
-        $query = new RaListingSearchQuery($token->getIdentityInstitution(), 1);
-        $query->setIdentityId($token->getIdentityInstitution());
-        $raListing = $this->service->search($query);
+        $raListing = $this->service->searchBy($token->getIdentityInstitution());
 
         if ($raListing->getTotalItems() > 1) {
             return VoterInterface::ACCESS_GRANTED;

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService as MiddlewareClientBundleRaListingService;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+
+class RaListingService
+{
+    /**
+     * @var MiddlewareClientBundleRaListingService
+     */
+    private $raListingService;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        MiddlewareClientBundleRaListingService $raListingService,
+        LoggerInterface $logger
+    ) {
+        $this->raListingService = $raListingService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param $institution
+     * @return ArrayChoiceList
+     */
+    public function createChoiceListFor($institution)
+    {
+        $query = new RaListingSearchQuery($institution, 1);
+        $query->setIdentityId($institution->getIdentityInstitution());
+
+        $collection = $this->raListingService->search($query);
+
+        if ($collection->getTotalItems() === 0) {
+            $this->logger->warning('No RAA institutions found for identity, unable to build the choice list for the RAA switcher');
+            return new ArrayChoiceList();
+        }
+
+        $choices = [];
+        foreach ($collection as $item) {
+            $choices[$item->institution] = $item->institution;
+        }
+
+        return new ArrayChoiceList($choices);
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authentication/Token/SamlTokenTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authentication/Token/SamlTokenTest.php
@@ -60,7 +60,7 @@ class SamlTokenTest extends TestCase
      * @group security
      * @group sraa
      */
-    public function institution_scope_of_saml_token_cannot_be_changed_when_not_sraa()
+    public function institution_scope_of_saml_token_cannot_be_changed_when_not_raa()
     {
         $this->setExpectedException(RuntimeException::class, 'Unauthorized to change institution scope');
 
@@ -68,7 +68,7 @@ class SamlTokenTest extends TestCase
 
         $samlToken = new SamlToken(
             new Loa(Loa::LOA_1, 'http://some.url.tld/authentication/loa1'),
-            ['ROLE_RAA', 'ROLE_RA']
+            ['ROLE_RA']
         );
         $samlToken->setUser($identity);
 

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
-namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Voter;
+namespace Surfnet\StepupRa\RaBundle\Tests\Security\Authorization\Voter;
 
 use Mockery as m;
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\StepupMiddlewareClientBundle\Configuration\Dto\InstitutionConfigurationOptions;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Security\Authorization\Context\InstitutionContext;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedInOtherInstitutionVoter;
 use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsServiceInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Security\Authorization\Voter;
+
+use Mockery as m;
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListingCollection;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
+use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Role\Role;
+
+class AllowedToSwitchInstitutionVoterTest extends TestCase
+{
+    /**
+     * @test
+     * @group security
+     * @dataProvider scenarios
+     */
+    public function test_view_audit_log(
+        $expectation,
+        array $actorRoles,
+        $raListingCount,
+        $attributes
+    )
+    {
+        $token = m::mock(SamlToken::class);
+        $token
+            ->shouldReceive('getRoles')
+            ->once()
+            ->andReturn($actorRoles);
+
+        $token
+            ->shouldReceive('getIdentityInstitution')
+            ->once()
+            ->andReturn('institution-a.example.com');
+
+        $collection = m::mock(RaListingCollection::class);
+        $collection
+            ->shouldReceive('getTotalItems')
+            ->andReturn($raListingCount);
+
+        $service = m::mock(RaListingService::class);
+        $service
+            ->shouldReceive('search')
+            ->andReturn($collection);
+
+        $voter = new AllowedToSwitchInstitutionVoter($service);
+
+        $this->assertEquals(
+            $expectation,
+            $voter->vote($token, null, $attributes)
+        );
+    }
+
+    public function scenarios()
+    {
+        return [
+            'raa-with-two-institutions' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RAA']),
+                2,
+                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
+            ],
+            'raa-with-multiple-institutions' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_RAA']),
+                8,
+                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
+            ],
+            'sraa-with-multiple-institutions' => [
+                VoterInterface::ACCESS_GRANTED,
+                $this->getRoles(['ROLE_SRAA']),
+                8,
+                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
+            ],
+            'raa-with-one-institution' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_RAA']),
+                1,
+                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
+            ],
+            'sraa-with-one-institution' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_SRAA']),
+                1,
+                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
+            ],
+            'ra-insufficiant-role' => [
+                VoterInterface::ACCESS_DENIED,
+                $this->getRoles(['ROLE_RA']),
+                3,
+                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
+            ],
+            'raa-with-invalid-attributes' => [
+                VoterInterface::ACCESS_ABSTAIN,
+                $this->getRoles(['ROLE_RAA']),
+                3,
+                ['sraa_switcher']
+            ],
+            'sraa-with-invalid-attributes' => [
+                VoterInterface::ACCESS_ABSTAIN,
+                $this->getRoles(['ROLE_SRAA']),
+                3,
+                ['sraa_switcher']
+            ],
+        ];
+    }
+
+
+    private function getRoles(array $rawRoles)
+    {
+        $roles = [];
+        foreach ($rawRoles as $role){
+            $roles[] = new Role($role);
+        }
+        return $roles;
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
@@ -21,9 +21,9 @@ namespace Surfnet\StepupRa\RaBundle\Tests\Security\Authorization\Voter;
 use Mockery as m;
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListingCollection;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter;
+use Surfnet\StepupRa\RaBundle\Service\RaListingService;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Role\Role;
 
@@ -59,7 +59,7 @@ class AllowedToSwitchInstitutionVoterTest extends TestCase
 
         $service = m::mock(RaListingService::class);
         $service
-            ->shouldReceive('search')
+            ->shouldReceive('searchBy')
             ->andReturn($collection);
 
         $voter = new AllowedToSwitchInstitutionVoter($service);


### PR DESCRIPTION
This switcher is used by RAA users to change between the institutions
they are RAA for.

This switcher is a copy of the SRAA switcher and behaves in a similar
fashion. The difference between them is that the SRAA can switch to all
institutions, and the RAA can only switch to institutions it is actually
RAA for.

The SamlToken was updated and set with a field that stores the 'home'
institution of the RAA. This to ensure the RAA can only switch to his
own institutions.