### PR TITLE
Determine user RA(A) institutions from ra listing

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
@@ -46,7 +46,7 @@ class RaaController extends Controller
 
         $raaSwitcherOptions = $this
             ->getRaListingService()
-            ->createChoiceListFor($token->getIdentityInstitution());
+            ->createChoiceListFor($identity->id, $token->getIdentityInstitution());
 
         $command = new ChangeRaaInstitutionCommand();
         $command->institution = $institution;

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
@@ -70,7 +70,7 @@ class AllowedToSwitchInstitutionVoter implements VoterInterface
             return VoterInterface::ACCESS_DENIED;
         }
 
-        $raListing = $this->service->searchBy($token->getIdentityInstitution());
+        $raListing = $this->service->searchBy($token->getUser()->id, $token->getIdentityInstitution());
 
         if ($raListing->getTotalItems() > 1) {
             return VoterInterface::ACCESS_GRANTED;

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
@@ -44,12 +44,13 @@ class RaListingService
     }
 
     /**
-     * @param $institution
+     * @param string $identityId
+     * @param string $institution
      * @return array
      */
-    public function createChoiceListFor($institution)
+    public function createChoiceListFor($identityId, $institution)
     {
-        $collection = $this->searchBy($institution);
+        $collection = $this->searchBy($identityId, $institution);
 
         if ($collection->getTotalItems() === 0) {
             $this->logger->warning('No RAA institutions found for identity, unable to build the choice list for the RAA switcher');
@@ -67,13 +68,14 @@ class RaListingService
     }
 
     /**
+     * @param string $identityId
      * @param string $institution
      * @return RaListingCollection
      */
-    public function searchBy($institution)
+    public function searchBy($identityId, $institution)
     {
         $query = new RaListingSearchQuery($institution, 1);
-        //$query->setIdentityId($institution);
+        $query->setIdentityId($identityId);
         return $this->raListingService->search($query);
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupRa\RaBundle\Tests\Security\Authorization\Voter;
 
 use Mockery as m;
 use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListingCollection;
 use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Security\Authorization\Voter\AllowedToSwitchInstitutionVoter;
@@ -41,11 +42,18 @@ class AllowedToSwitchInstitutionVoterTest extends TestCase
         $attributes
     )
     {
+        $user = new Identity();
+        $user->id = '47820bdd-7e48-46e5-916b-0b38b65f4d6b';
+
         $token = m::mock(SamlToken::class);
         $token
             ->shouldReceive('getRoles')
             ->once()
             ->andReturn($actorRoles);
+
+        $token
+            ->shouldReceive('getUser')
+            ->andReturn($user);
 
         $token
             ->shouldReceive('getIdentityInstitution')


### PR DESCRIPTION
By filtering the ra listing on the identity id we can see which
institutions the current RA(A) is RA(A) for. If more than on result
is shown, the RAA switcher is shown.