### PR TITLE
Display the ra institution in auditlog

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -34,22 +34,22 @@
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
         <source>ra.auditlog.action.accredited_as_ra</source>
-        <target>Accredited as RA</target>
+        <target>Accredited as RA @ %ra_institution%</target>
         <jms:reference-file line="45">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="66b320bfe1f15eabe6e0baa04e94b71c2152f8e2" resname="ra.auditlog.action.accredited_as_raa">
         <source>ra.auditlog.action.accredited_as_raa</source>
-        <target>Accredited as RAA</target>
+        <target>Accredited as RAA @ %ra_institution%</target>
         <jms:reference-file line="46">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ba50c2f5a7066cd14d8ae1f33c5f4decc892d0b7" resname="ra.auditlog.action.appointed_as_ra">
         <source>ra.auditlog.action.appointed_as_ra</source>
-        <target>Appointed as RA</target>
+        <target>Appointed as RA @ %ra_institution%</target>
         <jms:reference-file line="47">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f1a9c08794cd9c91a7f63841cc1c9ff61c3da452" resname="ra.auditlog.action.appointed_as_raa">
         <source>ra.auditlog.action.appointed_as_raa</source>
-        <target>Appointed as RAA</target>
+        <target>Appointed as RAA @ %ra_institution%</target>
         <jms:reference-file line="48">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c05a55d8f3ef06afe4f9d81883c0cd6dc415933" resname="ra.auditlog.action.bootstrapped">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -34,22 +34,22 @@
       </trans-unit>
       <trans-unit id="37836182b3260cbaf343a44bfb622776839666cc" resname="ra.auditlog.action.accredited_as_ra">
         <source>ra.auditlog.action.accredited_as_ra</source>
-        <target>Geaccrediteerd als RA</target>
+        <target>Geaccrediteerd als RA @ %ra_institution%</target>
         <jms:reference-file line="45">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="66b320bfe1f15eabe6e0baa04e94b71c2152f8e2" resname="ra.auditlog.action.accredited_as_raa">
         <source>ra.auditlog.action.accredited_as_raa</source>
-        <target>Geaccrediteerd als RAA</target>
+        <target>Geaccrediteerd als RAA @ %ra_institution%</target>
         <jms:reference-file line="46">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ba50c2f5a7066cd14d8ae1f33c5f4decc892d0b7" resname="ra.auditlog.action.appointed_as_ra">
         <source>ra.auditlog.action.appointed_as_ra</source>
-        <target>RA rol toegewezen gekregen</target>
+        <target>RA rol toegewezen gekregen @ %ra_institution%</target>
         <jms:reference-file line="47">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f1a9c08794cd9c91a7f63841cc1c9ff61c3da452" resname="ra.auditlog.action.appointed_as_raa">
         <source>ra.auditlog.action.appointed_as_raa</source>
-        <target>RAA rol toegewezen gekregen</target>
+        <target>RAA rol toegewezen gekregen @ %ra_institution%</target>
         <jms:reference-file line="48">/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c05a55d8f3ef06afe4f9d81883c0cd6dc415933" resname="ra.auditlog.action.bootstrapped">

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/auditLog.html.twig
@@ -36,7 +36,7 @@
                 <tr>
                     <td>{{ logEntry.secondFactorIdentifier }}</td>
                     <td>{{ logEntry.secondFactorType|trans_second_factor_type }}</td>
-                    <td>{{ ('ra.auditlog.action.' ~ logEntry.action)|trans }}</td>
+                    <td>{{ ('ra.auditlog.action.' ~ logEntry.action)|trans({'%ra_institution%': logEntry.raInstitution}) }}</td>
                     <td><time datetime="{{ logEntry.recordedOn.format('c') }}">{{ logEntry.recordedOn.format("Y-m-d H:i e") }}</time></td>
                     <td>{{ logEntry.actorCommonName }}</td>
                     <td>{{ logEntry.actorInstitution }}</td>


### PR DESCRIPTION
When an ra management related auditlog entry is displayed, the ra
institution is echoed in the action text. Resulting in something like:

"Accredited as RA @ institution-a"

See: https://github.com/OpenConext/Stepup-RA/pull/181
See: https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/71
See: https://github.com/OpenConext/Stepup-Middleware/pull/253