### PR TITLE
 Allow all RA roles to change the institution scope

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/security.yml
@@ -13,6 +13,7 @@ services:
             - "@ra.service.identity"
             - "@surfnet_saml.saml.attribute_dictionary"
             - "@ra.service.institution_configuration_options"
+            - "@ra.service.ra_listing"
             - "@logger"
 
     ra.security.authentication.saml_interaction:

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
@@ -92,9 +92,9 @@ class SamlToken extends AbstractToken
             return $role->getRole();
         }, $this->getRoles());
 
-        if (!in_array('ROLE_SRAA', $roles) && !in_array('ROLE_RAA', $roles)) {
+        if (!in_array('ROLE_SRAA', $roles) && !in_array('ROLE_RAA', $roles) && !in_array('ROLE_RA', $roles)) {
             throw new RuntimeException(sprintf(
-                'Unauthorized to change institution scope to "%s": role (S)RAA required, found roles "%s"',
+                'Unauthorized to change institution scope to "%s": role (S)RA(A) required, found roles "%s"',
                 $institution,
                 implode(', ', $roles)
             ));

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authentication/Token/SamlTokenTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authentication/Token/SamlTokenTest.php
@@ -60,7 +60,7 @@ class SamlTokenTest extends TestCase
      * @group security
      * @group sraa
      */
-    public function institution_scope_of_saml_token_cannot_be_changed_when_not_raa()
+    public function institution_scope_of_saml_token_cannot_be_changed_when_not_ra()
     {
         $this->setExpectedException(RuntimeException::class, 'Unauthorized to change institution scope');
 
@@ -68,7 +68,7 @@ class SamlTokenTest extends TestCase
 
         $samlToken = new SamlToken(
             new Loa(Loa::LOA_1, 'http://some.url.tld/authentication/loa1'),
-            ['ROLE_RA']
+            ['ROLE_ARA']
         );
         $samlToken->setUser($identity);
 
@@ -81,11 +81,12 @@ class SamlTokenTest extends TestCase
 
     /**
      * @test
+     * @dataProvider allowedRoles
      * @group authorization
      * @group security
      * @group sraa
      */
-    public function institution_scope_of_saml_token_can_be_changed_when_sraa()
+    public function institution_scope_of_saml_token_can_be_changed($role)
     {
         $expectedInstitution = 'surfnet.nl';
 
@@ -98,7 +99,7 @@ class SamlTokenTest extends TestCase
 
         $samlToken = new SamlToken(
             new Loa(Loa::LOA_1, 'http://some.url.tld/authentication/loa1'),
-            ['ROLE_SRAA'],
+            [$role],
             $oldInstitutionConfigurationOptions
         );
         $samlToken->setUser($identity);
@@ -112,6 +113,7 @@ class SamlTokenTest extends TestCase
         $this->assertSame($expectedInstitution, $samlToken->getUser()->institution);
         $this->assertSame($newInstitutionConfigurationOptions, $samlToken->getInstitutionConfigurationOptions());
     }
+
 
     /**
      * @test
@@ -132,5 +134,14 @@ class SamlTokenTest extends TestCase
         $newInstitutionConfigurationOptions->showRaaContactInformation = false;
 
         $samlToken->changeInstitutionScope('surfnet.nl', $newInstitutionConfigurationOptions);
+    }
+
+    public function allowedRoles()
+    {
+        return [
+            'ra-is-allowed' => ['ROLE_RA'],
+            'raa-is-allowed' => ['ROLE_RAA'],
+            'sraa-is-allowed' => ['ROLE_SRAA'],
+        ];
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedInOtherInstitutionVoterTest.php
@@ -147,21 +147,15 @@ class AllowedInOtherInstitutionVoterTest extends TestCase
     private  function denied()
     {
         return [
-            'only-raas-are-granted-access' => [
-                VoterInterface::ACCESS_DENIED,
-                $this->getRoles(['ROLE_RA']),
-                $this->getOptions(['ra' => [], 'raa' => ['a', 'b']]),
-                $this->getContext('a', 'b'),
-            ],
             'no-ample-institution-config-options-available' => [
                 VoterInterface::ACCESS_DENIED,
-                $this->getRoles(['ROLE_RA']),
+                $this->getRoles(['ROLE_RAA']),
                 $this->getOptions(['ra' => [], 'raa' => []]),
                 $this->getContext('a', 'b'),
             ],
             'not-configured-target-institution' => [
                 VoterInterface::ACCESS_DENIED,
-                $this->getRoles(['ROLE_RA']),
+                $this->getRoles(['ROLE_RAA']),
                 $this->getOptions(['ra' => ['a'], 'raa' => []]),
                 $this->getContext('a', 'b'),
             ],

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
@@ -111,12 +111,6 @@ class AllowedToSwitchInstitutionVoterTest extends TestCase
                 1,
                 [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
             ],
-            'ra-insufficiant-role' => [
-                VoterInterface::ACCESS_DENIED,
-                $this->getRoles(['ROLE_RA']),
-                3,
-                [AllowedToSwitchInstitutionVoter::RAA_SWITCHING]
-            ],
             'raa-with-invalid-attributes' => [
                 VoterInterface::ACCESS_ABSTAIN,
                 $this->getRoles(['ROLE_RAA']),


### PR DESCRIPTION
The RA must also be able to switch to the institution it is RA for.
Previously this was only allowed for (S)RAA users via the institution
switcher. Now that the SAML provider also switches to another inst.
outside the SHO of the authenticating user, the change is authorization
was required.