### PR TITLE
Update authentication in order to find identities

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -92,7 +92,7 @@ class SamlProvider implements AuthenticationProviderInterface
         $nameId      = $translatedAssertion->getNameID();
         $institution = $this->getSingleStringValue('schacHomeOrganization', $translatedAssertion);
 
-        $identity = $this->identityService->findByNameIdAndInstitution($nameId, $institution);
+        $identity = $this->identityService->findByNameId($nameId);
 
         // if no identity can be found, we're done.
         if ($identity === null) {

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
@@ -72,7 +72,7 @@ class AllowedToSwitchInstitutionVoter implements VoterInterface
 
         $raListing = $this->service->searchBy($token->getUser()->id, $token->getIdentityInstitution());
 
-        if ($raListing->getTotalItems() >= 1) {
+        if ($raListing->getTotalItems() > 1) {
             return VoterInterface::ACCESS_GRANTED;
         }
 

--- a/src/Surfnet/StepupRa/RaBundle/Service/IdentityService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/IdentityService.php
@@ -106,13 +106,12 @@ class IdentityService implements UserProviderInterface
 
     /**
      * @param string $nameId
-     * @param string $institution
      * @return null|\Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity
      * @throws \Surfnet\StepupRa\RaBundle\Exception\RuntimeException
      */
-    public function findByNameIdAndInstitution($nameId, $institution)
+    public function findByNameId($nameId)
     {
-        $searchQuery = new IdentitySearchQuery($institution);
+        $searchQuery = new IdentitySearchQuery();
         $searchQuery->setNameId($nameId);
 
         try {


### PR DESCRIPTION
In order to ensure we can find an identity, we no longer need to pass
the institution of that identity. As the RA(A) might be RA for an
institution it does not have a SHO for.

To achieve this goal, the IdentitySearchQuery has been updated, the
Institution parameter has been made optional. This change was applied
in:

 - https://github.com/OpenConext/Stepup-RA/pull/183
 - https://github.com/OpenConext/Stepup-SelfService/pull/161
 - https://github.com/OpenConext/Stepup-Middleware-clientbundle/pull/72
 - https://github.com/OpenConext/Stepup-Middleware/pull/255