### PR TITLE
Will make the RAA logic watch for RA institution instead of user institution

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -188,11 +188,11 @@ class RaManagementController extends Controller
 
     /**
      * @param Request $request
-     * @param         $identityId
-     * @param         $institution
+     * @param string  $identityId
+     * @param string  $institution
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function amendRaInformationAction(Request $request, $identityId,$institution)
+    public function amendRaInformationAction(Request $request, $identityId, $institution)
     {
         $this->denyAccessUnlessGranted(['ROLE_RAA', 'ROLE_SRAA']);
 
@@ -375,32 +375,10 @@ class RaManagementController extends Controller
      */
     private function getIdentityInstitution()
     {
-        if (!$this->getUserIsSraa()) {
-            /**
-             * @var SamlToken $token
-             */
-            $token  = $this->get('security.token_storage')->getToken();
-            return $token->getSchacHomeInstitution();
-        }
-
-        return $this->getUser()->institution;
-    }
-
-    /**
-     * @return string
-     */
-    private function getUserIsSraa()
-    {
         /**
          * @var SamlToken $token
          */
         $token  = $this->get('security.token_storage')->getToken();
-        foreach ($token->getRoles() as $role){
-            if ($role->getRole() == 'ROLE_SRAA') {
-                return true;
-            }
-        }
-
-        return false;
+        return $token->getIdentityOriginalInstitution();
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
@@ -46,7 +46,7 @@ class RaaController extends Controller
 
         $raaSwitcherOptions = $this
             ->getRaListingService()
-            ->createChoiceListFor($identity->id, $token->getIdentityInstitution());
+            ->createChoiceListFor($identity->id, $token->getSchacHomeInstitution());
 
         $command = new ChangeRaaInstitutionCommand();
         $command->institution = $institution;

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
@@ -129,17 +129,17 @@ ra_management_create_ra:
     defaults: { _controller: SurfnetStepupRaRaBundle:RaManagement:createRa }
 
 ra_management_amend_ra_information:
-    path:     /management/amend-ra-information/{identityId}
+    path:     /management/amend-ra-information/{identityId}/{institution}
     methods:  [GET, POST]
     defaults: { _controller: SurfnetStepupRaRaBundle:RaManagement:amendRaInformation }
 
 ra_management_change_ra_role:
-    path:     /management/change-role/{identityId}
+    path:     /management/change-role/{identityId}/{institution}
     methods:  [GET, POST]
     defaults: { _controller: SurfnetStepupRaRaBundle:RaManagement:changeRaRole }
 
 ra_management_retract_registration_authority:
-    path:     /management/retract-registration-authority/{identityId}
+    path:     /management/retract-registration-authority/{identityId}/{institution}
     methods:  [GET, POST]
     defaults: { _controller: SurfnetStepupRaRaBundle:RaManagement:retractRegistrationAuthority }
 

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/RaManagement/manage.html.twig
@@ -28,10 +28,10 @@
                             {{ authority.raInstitution }}
                         </td>
                         <td>
-                            <a href="{{ path('ra_management_amend_ra_information', {identityId: authority.identityId}) }}" class="btn btn-primary" role="button">
+                            <a href="{{ path('ra_management_amend_ra_information', {identityId: authority.identityId, institution: authority.raInstitution}) }}" class="btn btn-primary" role="button">
                                 {{ 'ra.management.overview.update_information'|trans }}
                             </a>
-                            <a href="{{ path('ra_management_retract_registration_authority', {identityId: authority.identityId}) }}" class="btn btn-warning" role="button">
+                            <a href="{{ path('ra_management_retract_registration_authority', {identityId: authority.identityId, institution: authority.raInstitution}) }}" class="btn btn-warning" role="button">
                                 {{ 'ra.management.overview.remove_as_ra'|trans }}
                             </a>
                         </td>

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Provider/SamlProvider.php
@@ -137,7 +137,7 @@ class SamlProvider implements AuthenticationProviderInterface
         }
 
         // set the token
-        $authenticatedToken = new SamlToken($token->getLoa(), $roles, $institutionConfigurationOptions);
+        $authenticatedToken = new SamlToken($token->getLoa(), $roles, $institutionConfigurationOptions, $institution);
         $authenticatedToken->setUser($identity);
 
         // When dealing with a RA(A), determine for which institution the authenticating user should enter the RA environment

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
@@ -48,20 +48,14 @@ class SamlToken extends AbstractToken
     private $raManagementInstitution;
 
     /**
-     * The SHO of the identity
-     *
-     * @var string
-     */
-    private $schacHomeOrganization;
-
-    /**
      * The identity institution is set with the SHO of the identity. This value is not overridden like the user
      * institution can be. This value can be used to get the identities institution regardless of the scope it
      * is performing RAA tasks for at this moment.
      *
      * @var string
      */
-    private $identityInstitution;
+    private $schacHomeOrganization;
+
 
     public function __construct(
         Loa $loa,
@@ -139,7 +133,6 @@ class SamlToken extends AbstractToken
                 $this->loa,
                 $this->institutionConfigurationOptions,
                 $this->raManagementInstitution,
-                $this->identityInstitution,
                 $this->schacHomeOrganization,
             ]
         );
@@ -152,7 +145,6 @@ class SamlToken extends AbstractToken
             $this->loa,
             $this->institutionConfigurationOptions,
             $this->raManagementInstitution,
-            $this->identityInstitution,
             $this->schacHomeOrganization
             ) = unserialize(
                 $serialized
@@ -160,19 +152,6 @@ class SamlToken extends AbstractToken
 
         parent::unserialize($parent);
     }
-
-    /**
-     * @return string
-     */
-    public function getIdentityInstitution()
-    {
-        // If the identityInstitution is not yet set, fill it with the institution of the identity.
-        if (!$this->identityInstitution) {
-            $this->identityInstitution = $this->getUser()->institution;
-        }
-        return $this->identityInstitution;
-    }
-
 
     /**
      * @return string

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
@@ -48,6 +48,8 @@ class SamlToken extends AbstractToken
     private $raManagementInstitution;
 
     /**
+     * The SHO of the identity
+     *
      * @var string
      */
     private $schacHomeOrganization;
@@ -145,9 +147,16 @@ class SamlToken extends AbstractToken
 
     public function unserialize($serialized)
     {
-        list($parent, $this->loa, $this->institutionConfigurationOptions, $this->raManagementInstitution, $this->identityInstitution, $this->schacHomeOrganization) = unserialize(
-            $serialized
-        );
+        list(
+            $parent,
+            $this->loa,
+            $this->institutionConfigurationOptions,
+            $this->raManagementInstitution,
+            $this->identityInstitution,
+            $this->schacHomeOrganization
+            ) = unserialize(
+                $serialized
+            );
 
         parent::unserialize($parent);
     }
@@ -182,5 +191,34 @@ class SamlToken extends AbstractToken
     public function getSchacHomeInstitution()
     {
         return $this->schacHomeOrganization;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityOriginalInstitution()
+    {
+        if (!$this->isUserSraa()) {
+            return $this->getSchacHomeInstitution();
+        }
+
+        return $this->getUser()->institution;
+    }
+
+    /**
+     * @return string
+     */
+    private function isUserSraa()
+    {
+        /**
+         * @var SamlToken $token
+         */
+        foreach ($this->getRoles() as $role) {
+            if ($role->getRole() == 'ROLE_SRAA') {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authentication/Token/SamlToken.php
@@ -48,6 +48,11 @@ class SamlToken extends AbstractToken
     private $raManagementInstitution;
 
     /**
+     * @var string
+     */
+    private $schacHomeOrganization;
+
+    /**
      * The identity institution is set with the SHO of the identity. This value is not overridden like the user
      * institution can be. This value can be used to get the identities institution regardless of the scope it
      * is performing RAA tasks for at this moment.
@@ -59,13 +64,15 @@ class SamlToken extends AbstractToken
     public function __construct(
         Loa $loa,
         array $roles = [],
-        InstitutionConfigurationOptions $institutionConfigurationOptions = null
+        InstitutionConfigurationOptions $institutionConfigurationOptions = null,
+        $schacHomeOrganization = ''
     ) {
         parent::__construct($roles);
 
         $this->loa = $loa;
         $this->setAuthenticated(count($roles));
         $this->institutionConfigurationOptions = $institutionConfigurationOptions;
+        $this->schacHomeOrganization = $schacHomeOrganization;
     }
 
     /**
@@ -131,13 +138,14 @@ class SamlToken extends AbstractToken
                 $this->institutionConfigurationOptions,
                 $this->raManagementInstitution,
                 $this->identityInstitution,
+                $this->schacHomeOrganization,
             ]
         );
     }
 
     public function unserialize($serialized)
     {
-        list($parent, $this->loa, $this->institutionConfigurationOptions, $this->raManagementInstitution, $this->identityInstitution) = unserialize(
+        list($parent, $this->loa, $this->institutionConfigurationOptions, $this->raManagementInstitution, $this->identityInstitution, $this->schacHomeOrganization) = unserialize(
             $serialized
         );
 
@@ -166,5 +174,13 @@ class SamlToken extends AbstractToken
             return $this->getUser()->institution;
         }
         return $this->raManagementInstitution;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchacHomeInstitution()
+    {
+        return $this->schacHomeOrganization;
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
+++ b/src/Surfnet/StepupRa/RaBundle/Security/Authorization/Voter/AllowedToSwitchInstitutionVoter.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Security\Authorization\Voter;
 
 use InvalidArgumentException;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\StepupRa\RaBundle\Service\RaListingService;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -70,7 +71,8 @@ class AllowedToSwitchInstitutionVoter implements VoterInterface
             return VoterInterface::ACCESS_DENIED;
         }
 
-        $raListing = $this->service->searchBy($token->getUser()->id, $token->getIdentityInstitution());
+        /** @var $token SamlToken */
+        $raListing = $this->service->searchBy($token->getUser()->id, $token->getSchacHomeInstitution());
 
         if ($raListing->getTotalItems() > 1) {
             return VoterInterface::ACCESS_GRANTED;

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Authorization/Voter/AllowedToSwitchInstitutionVoterTest.php
@@ -56,7 +56,7 @@ class AllowedToSwitchInstitutionVoterTest extends TestCase
             ->andReturn($user);
 
         $token
-            ->shouldReceive('getIdentityInstitution')
+            ->shouldReceive('getSchacHomeInstitution')
             ->once()
             ->andReturn('institution-a.example.com');
 


### PR DESCRIPTION
The Raa switcher was removed but the RAA logic looked for the institution of the user and not the institution where a user was RAA for. So there was unexpected behavior occurring when a user was performing actions on behalf of a specific RAA institution. This should be fixed now.