### PR TITLE
Fix the token sorting PART II

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ branches:
   only:
     - master
     - develop
-    - release/2.8
+    - release/2.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.5
+**Bugfix**
+* Fix the token sorting PART II #192
+
 ## 2.10.4
 **Improvements**
 * Open help in new tab #187 

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -29,6 +29,10 @@ div.page-header {
     }
 }
 
+table th {
+    color: @brand-primary;
+}
+
 .ra-start-vetting-procedure-container {
     margin: 3em auto;
     max-width: 500px;

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
@@ -21,7 +21,7 @@
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.type'|trans, 'type') }}</th>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.name'|trans, 'name') }}</th>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.email'|trans, 'email') }}</th>
-                        <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.document_number'|trans, 'document_number') }}</th>
+                        <th>{{ 'ra.second_factor.search.column.document_number'|trans }}</th>
                         <th>{{ knp_pagination_sortable(pagination, 'ra.second_factor.search.column.status'|trans, 'status') }}</th>
                         <th></th>
                     </tr>


### PR DESCRIPTION
This was already fixed for FGA (release 17) but now also backported to release 16.

The document number sorting feature is now disabled. And the header is styled appropriately. There was no option to search on the document number, so no change was required for that.