### PR TITLE
Align buttons on 'Tokens' page

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 use Surfnet\StepupRa\RaBundle\Form\Extension\SecondFactorTypeChoiceList;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -75,15 +76,25 @@ class SearchRaSecondFactorsType extends AbstractType
             'required' => false,
         ]);
 
-        $builder->add('search', SubmitType::class, [
-            'label' => 'ra.form.ra_search_ra_second_factors.button.search',
-            'attr' => [ 'class' => 'btn btn-primary pull-left' ],
-        ]);
-
-        $builder->add('export', SubmitType::class, [
-            'label' => 'ra.form.ra_search_ra_second_factors.button.export',
-            'attr' => [ 'class' => 'btn btn-secondary pull-left' ],
-        ]);
+        $builder->add(
+            $builder->create(
+                'button-group',
+                FormType::class,
+                [
+                    'inherit_data' => true,
+                    'label' => false,
+                    'widget_form_group_attr' => ['class' => 'form-group button-group'],
+                ]
+            )
+            ->add('search', SubmitType::class, [
+                'label' => 'ra.form.ra_search_ra_second_factors.button.search',
+                'attr' => [ 'class' => 'btn btn-primary pull-left button-group-member' ],
+            ])
+            ->add('export', SubmitType::class, [
+                'label' => 'ra.form.ra_search_ra_second_factors.button.export',
+                'attr' => [ 'class' => 'btn btn-secondary pull-left button-group-member' ],
+            ])
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -143,31 +143,37 @@ form[name="ra_verify_phone_number"] {
         text-transform: uppercase;
     }
 }
-
-form[name="ra_search_ra_second_factors"] {
-    input#ra_search_ra_second_factors_name {
-        max-width: 300px;
-    }
-    input#ra_search_ra_second_factors_secondFactorId {
-        max-width: 200px;
-    }
-    input#ra_search_ra_second_factors_email {
-        max-width: 350px;
-    }
-    select {
-        max-width: 175px;
-    }
-    button#ra_search_ra_second_factors_export {
-        margin-left: 0.5em;
-    }
-    div.button-group {
-        margin-left: 25%;
-        div.form-group {
-            margin-right: 14px;
-            float: left;
-            button:first-child {
-                margin-left: 8px;
+.search-second-factors {
+    form[name="ra_search_ra_second_factors"] {
+        input#ra_search_ra_second_factors_name {
+            max-width: 300px;
+        }
+        input#ra_search_ra_second_factors_secondFactorId {
+            max-width: 200px;
+        }
+        input#ra_search_ra_second_factors_email {
+            max-width: 350px;
+        }
+        select {
+            max-width: 175px;
+        }
+        button#ra_search_ra_second_factors_export {
+            margin-left: 0.5em;
+        }
+        div.button-group {
+            margin-left: 25%;
+            div.form-group {
+                margin-right: 14px;
+                float: left;
+                button:first-child {
+                    margin-left: 8px;
+                }
             }
+        }
+    }
+    td.button-column {
+        .audit-log, .revoke {
+            margin: 0px 3px 3px 3px;
         }
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -160,6 +160,16 @@ form[name="ra_search_ra_second_factors"] {
     button#ra_search_ra_second_factors_export {
         margin-left: 0.5em;
     }
+    div.button-group {
+        margin-left: 25%;
+        div.form-group {
+            margin-right: 14px;
+            float: left;
+            button:first-child {
+                margin-left: 8px;
+            }
+        }
+    }
 }
 
 form[name="ra_search_ra_candidates"] {

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/SecondFactor/search.html.twig
@@ -37,7 +37,7 @@
                             <td>{{ secondFactor.email }}</td>
                             <td>{% if secondFactor.documentNumber is not empty %}{{ secondFactor.documentNumber}}{% else %}&mdash;{% endif %}</td>
                             <td>{{ ('ra.second_factor.search.status.'~secondFactor.status)|trans }}</td>
-                            <td>
+                            <td class="button-column">
                                 <a href="{{ path('ra_second_factor_auditlog', {identityId: secondFactor.identityId}) }}" class="btn btn-info audit-log">{{ 'ra.secondfactor.auditlog'|trans }}</a>
                                 {% if secondFactor.status != 'revoked' %}
                                 <button class="btn btn-warning revoke" data-toggle="modal" data-target="#revocationModal"


### PR DESCRIPTION
The search and export buttons have been aligned horizontally next to each other. On the vertical axis, the buttons are now positioned underneath the form elements instead of floating all the way in the gutter of the page on the left.

In addition, the audit log and remove buttons have also been styled subtly.