### PR TITLE
Widen the width of the menu

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -205,6 +205,12 @@ select[name="stepup_switch_locale[locale]"] {
     display: none;
 }
 
+.container {
+    @media (min-width: @screen-lg-min) {
+        width: 1190px;
+    }
+}
+
 .container-cancel-vetting {
     text-align: center;
 }


### PR DESCRIPTION
The main menu in LG viewport would not fit the six possible menu entries. In order to fit them, the container width was increased to 1190px.

See:
https://www.pivotaltracker.com/story/show/163391235/comments/198940053