### PR TITLE
Add missing get method to ra listing service

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
@@ -20,6 +20,7 @@ namespace Surfnet\StepupRa\RaBundle\Service;
 
 use Psr\Log\LoggerInterface;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService as ApiRaListingService;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaListingCommand;
 
@@ -74,5 +75,15 @@ final class RaListingService
         }
 
         return $this->apiRaListingService->search($query);
+    }
+
+    /**
+     * @param string $id
+     * @param string $institution
+     * @return null|RaListing
+     */
+    public function get($id, $institution)
+    {
+        return $this->apiRaListingService->get($id, $institution);
     }
 }


### PR DESCRIPTION
The get method of the ra listing method is missing because a new
ra listing service class was introduced.