### PR TITLE
Add actorId to ra-listing endpoint

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "c173815ea42744830da2a5ac1e82061a",
@@ -2367,16 +2367,16 @@
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
-            "version": "3.0.6",
+            "version": "3.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "6e4ae8bf6ced3d971cde097ceb2f00891cb36040"
+                "reference": "88c2b05395d2dbd8cf16f0acb74509f9fcb0c3ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/6e4ae8bf6ced3d971cde097ceb2f00891cb36040",
-                "reference": "6e4ae8bf6ced3d971cde097ceb2f00891cb36040",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/88c2b05395d2dbd8cf16f0acb74509f9fcb0c3ce",
+                "reference": "88c2b05395d2dbd8cf16f0acb74509f9fcb0c3ce",
                 "shasum": ""
             },
             "require": {
@@ -2416,7 +2416,7 @@
                 "Apache-2.0"
             ],
             "description": "Symfony2 bundle for consuming the Step-up Middleware API.",
-            "time": "2019-02-13T08:18:38+00:00"
+            "time": "2019-02-14T14:10:00+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -166,7 +166,7 @@ class RaManagementController extends Controller
 
         $raCandidate = $this->getRaCandidateService()->getRaCandidate($identityId, $this->getUser()->institution, $this->getUser()->id);
 
-        if (!$raCandidate) {
+        if (!$raCandidate->raCandidate) {
             $logger->warning(sprintf('RaCandidate based on identity "%s" not found', $identityId));
             throw new NotFoundHttpException();
         }
@@ -221,7 +221,7 @@ class RaManagementController extends Controller
         $logger = $this->get('logger');
         $logger->notice(sprintf("Loading information amendment form for RA(A) '%s'", $identityId));
 
-        $raListing = $this->getRaListingService()->get($identityId, $raInstitution);
+        $raListing = $this->getRaListingService()->get($identityId, $raInstitution,  $this->getUser()->institution, $this->getUser()->id);
 
         if (!$raListing) {
             $logger->warning(sprintf("RA listing for identity ID '%s' not found", $identityId));
@@ -268,7 +268,7 @@ class RaManagementController extends Controller
 
         $logger->notice(sprintf("Loading retract registration authority form for RA(A) '%s'", $identityId));
 
-        $raListing = $this->getRaListingService()->get($identityId, $raInstitution);
+        $raListing = $this->getRaListingService()->get($identityId, $raInstitution, $this->getUser()->institution, $this->getUser()->id);
         if (!$raListing) {
             $logger->warning(sprintf("RA listing for identity ID '%s@%s' not found", $identityId, $this->getUser()->institution));
             throw new NotFoundHttpException(sprintf("RA listing for identity ID '%s' not found", $identityId));

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -221,7 +221,7 @@ class RaManagementController extends Controller
         $logger = $this->get('logger');
         $logger->notice(sprintf("Loading information amendment form for RA(A) '%s'", $identityId));
 
-        $raListing = $this->getRaListingService()->get($identityId, $raInstitution,  $this->getUser()->institution, $this->getUser()->id);
+        $raListing = $this->getRaListingService()->get($identityId, $raInstitution, $this->getUser()->institution, $this->getUser()->id);
 
         if (!$raListing) {
             $logger->warning(sprintf("RA listing for identity ID '%s' not found", $identityId));

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
@@ -133,11 +133,6 @@ ra_management_amend_ra_information:
     methods:  [GET, POST]
     defaults: { _controller: SurfnetStepupRaRaBundle:RaManagement:amendRaInformation }
 
-ra_management_change_ra_role:
-    path:     /management/change-role/{identityId}
-    methods:  [GET, POST]
-    defaults: { _controller: SurfnetStepupRaRaBundle:RaManagement:changeRaRole }
-
 ra_management_retract_registration_authority:
     path:     /management/retract-registration-authority/{identityId}/{raInstitution}
     methods:  [GET, POST]

--- a/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/RaListingService.php
@@ -23,6 +23,7 @@ use Surfnet\StepupMiddlewareClient\Identity\Dto\RaListingSearchQuery;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaListing;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Service\RaListingService as ApiRaListingService;
 use Surfnet\StepupRa\RaBundle\Command\SearchRaListingCommand;
+use Surfnet\StepupRa\RaBundle\Exception\InvalidArgumentException;
 
 final class RaListingService
 {
@@ -78,12 +79,30 @@ final class RaListingService
     }
 
     /**
-     * @param string $id
+     * @param string $identityId
      * @param string $institution
+     * @param string $actorInstitution
+     * @param string $actorId
      * @return null|RaListing
      */
-    public function get($id, $institution)
+    public function get($identityId, $institution, $actorInstitution, $actorId)
     {
-        return $this->apiRaListingService->get($id, $institution);
+        if (!is_string($identityId)) {
+            throw InvalidArgumentException::invalidType('string', 'identityId', $identityId);
+        }
+
+        if (!is_string($institution)) {
+            throw InvalidArgumentException::invalidType('string', 'institution', $institution);
+        }
+
+        if (!is_string($actorInstitution)) {
+            throw InvalidArgumentException::invalidType('string', 'actorInstitution', $actorInstitution);
+        }
+
+        if (!is_string($actorId)) {
+            throw InvalidArgumentException::invalidType('string', 'actorId', $actorId);
+        }
+
+        return $this->apiRaListingService->get($identityId, $institution, $actorInstitution, $actorId);
     }
 }


### PR DESCRIPTION
When requesting a single ra listing the actorId was not send so
a ra could be returned while this shouldn't be allowed.