### PR TITLE
Update button alignment on 'create-ra' page

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 use Surfnet\StepupRa\RaBundle\Form\Extension\RaRoleChoiceList;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -51,15 +52,26 @@ class CreateRaType extends AbstractType
                 'label'       => 'ra.management.form.create_ra.label.institution',
                 'choices' => $options
             ])
-            ->add('create_ra', SubmitType::class, [
-                'label' => 'ra.management.form.create_ra.label.create_ra',
-                'attr' => ['class' => 'btn btn-primary pull-right create-ra']
-            ])
-            ->add('cancel', AnchorType::class, [
-                'label' => 'ra.management.form.create_ra.label.cancel',
-                'route' => 'ra_management_ra_candidate_search',
-                'attr'  => ['class' => 'btn btn-link pull-right cancel']
-            ])
+            ->add(
+                $builder->create(
+                    'button-group',
+                    FormType::class,
+                    [
+                        'inherit_data' => true,
+                        'label' => false,
+                        'widget_form_group_attr' => ['class' => 'form-group button-group'],
+                    ]
+                )
+                ->add('create_ra', SubmitType::class, [
+                    'label' => 'ra.management.form.create_ra.label.create_ra',
+                    'attr' => ['class' => 'btn btn-primary create-ra button-group-member']
+                ])
+                ->add('cancel', AnchorType::class, [
+                    'label' => 'ra.management.form.create_ra.label.cancel',
+                    'route' => 'ra_management_ra_candidate_search',
+                    'attr'  => ['class' => 'btn btn-link cancel pull-right button-group-member'],
+                ])
+            )
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -180,6 +180,25 @@ select.form-control {
     }
 }
 
+form[name="ra_management_create_ra"] {
+    div.button-group {
+        div {
+            left: 16%;
+            margin-top: 0.5em;
+
+            @media (max-width: @screen-sm-max) {
+                left: 0.5em;
+            }
+            div {
+                position: relative;
+                width: 110px;
+                float: left;
+            }
+        }
+    }
+}
+
+
 form[name="ra_search_ra_candidates"] {
     input#ra_search_ra_candidates_name {
         max-width: 300px;


### PR DESCRIPTION
The Create Ra and cancel buttons now align horizontally and are
displayed like the other buttons. Vertically positioned under the
other form input elements.

This covers task two from this Pivotal story:
https://www.pivotaltracker.com/story/show/164244365