### PR TITLE
Set maximum form text element width

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -33,6 +33,10 @@ table.orderable th {
     color: @brand-primary;
 }
 
+form input[type=text] {
+    max-width: 350px;
+}
+
 .ra-start-vetting-procedure-container {
     margin: 3em auto;
     max-width: 500px;
@@ -155,9 +159,6 @@ select.form-control {
         }
         input#ra_search_ra_second_factors_secondFactorId {
             max-width: 200px;
-        }
-        input#ra_search_ra_second_factors_email {
-            max-width: 350px;
         }
         button#ra_search_ra_second_factors_export {
             margin-left: 0.5em;


### PR DESCRIPTION
This prevents the text fields from becoming 100% wide, which does not
look visually attractive.

Other custom widths that where set have been left in place, except if
they matched the now set max width

Pivotal reference:
https://www.pivotaltracker.com/story/show/164244268 (task 2)