### PR TITLE
Fix institution switcher for ra configuration page

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/ProfileController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/ProfileController.php
@@ -18,19 +18,27 @@
 
 namespace Surfnet\StepupRa\RaBundle\Controller;
 
+use Surfnet\StepupRa\RaBundle\Service\ProfileService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 final class ProfileController extends Controller
 {
     public function profileAction()
     {
-        $token  = $this->get('security.token_storage')->getToken();
         $logger = $this->get('logger');
 
         $logger->notice('Opening profile page');
 
-        $identity = $token->getUser();
-        $profile = $this->get('ra.service.profile')->findByIdentityId($identity->id);
+        $identity = $this->getUser();
+        $profile = $this->getProfileService()->findByIdentityId($identity->id);
         return $this->render('SurfnetStepupRaRaBundle:Profile:profile.html.twig', ['profile' => $profile]);
+    }
+
+    /**
+     * @return ProfileService
+     */
+    private function getProfileService()
+    {
+        return $this->get('ra.service.profile');
     }
 }


### PR DESCRIPTION
The ra switcher was removed but certain logic was still used
by the switcher on the institution configuration page.
This will also use the profile endpoint to determine the institutions
we could view the settings from.