### PR TITLE
Fix accredit candidate command usage

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -29,8 +29,8 @@ use Surfnet\StepupRa\RaBundle\Form\Type\CreateRaType;
 use Surfnet\StepupRa\RaBundle\Form\Type\RetractRegistrationAuthorityType;
 use Surfnet\StepupRa\RaBundle\Form\Type\SearchRaCandidatesType;
 use Surfnet\StepupRa\RaBundle\Form\Type\SearchRaListingType;
-use Surfnet\StepupRa\RaBundle\Service\InstitutionConfigurationOptionsService;
 use Surfnet\StepupRa\RaBundle\Service\RaListingService;
+use Surfnet\StepupRa\RaBundle\Value\RoleAtInstitution;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -184,10 +184,11 @@ class RaManagementController extends Controller
         }, $raCandidate->institutions->getElements());
         $selectOptions = array_combine($options, $options);
 
-        $command                   = new AccreditCandidateCommand();
-        $command->identityId       = $identityId;
-        $command->institution      = $raCandidate->raCandidate->institution;
-        $command->raInstitution    = $this->getUser()->institution;
+        $command = new AccreditCandidateCommand();
+        $command->identityId = $identityId;
+        $command->institution = $raCandidate->raCandidate->institution;
+        $command->roleAtInstitution = new RoleAtInstitution();
+        $command->roleAtInstitution->setInstitution($this->getUser()->institution);
         $command->availableInstitutions = $selectOptions;
 
         $form = $this->createForm(CreateRaType::class, $command)->handleRequest($request);

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
@@ -19,9 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Surfnet\StepupRa\RaBundle\Command\AccreditCandidateCommand;
-use Surfnet\StepupRa\RaBundle\Form\Extension\RaRoleChoiceList;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;


### PR DESCRIPTION
The roleAtInstitution needed to be implemented instead of the no longer existing ra institute field.

https://www.pivotaltracker.com/story/show/164400522