### PR TITLE
Apply fix from #185 to other paginate calls

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -60,7 +60,7 @@ class RaManagementController extends Controller
         $raList = $service->search($searchQuery);
 
         $pagination = $this->getPaginator()->paginate(
-            $raList->getTotalItems() > 0 ? array_fill(0, $raList->getTotalItems(), 1) : [],
+            $raList->getTotalItems() > 0 ? $raList->getElements() : [],
             $raList->getCurrentPage(),
             $raList->getItemsPerPage()
         );
@@ -109,7 +109,7 @@ class RaManagementController extends Controller
         $raCandidateList = $service->search($command);
 
         $pagination = $this->getPaginator()->paginate(
-            $raCandidateList->getTotalItems() > 0 ? array_fill(4, $raCandidateList->getTotalItems(), 1) : [],
+            $raCandidateList->getTotalItems() > 0 ? $raCandidateList->getElements() : [],
             $raCandidateList->getCurrentPage(),
             $raCandidateList->getItemsPerPage()
         );

--- a/src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/SecondFactorController.php
@@ -193,7 +193,7 @@ final class SecondFactorController extends Controller
         $auditLog = $this->getAuditLogService()->getAuditlog($command);
 
         $pagination = $this->get('knp_paginator')->paginate(
-            $auditLog->getTotalItems() > 0 ? array_fill(0, $auditLog->getTotalItems(), 1) : [],
+            $auditLog->getTotalItems() > 0 ? $auditLog->getElements() : [],
             $auditLog->getCurrentPage(),
             $auditLog->getItemsPerPage()
         );


### PR DESCRIPTION
Other controller actions use the paginator to paginate their results, sorting was broken in certain situations.

This was fixed for the token overview in #185, but not fixed for the other paginator usages.

This should fix the `UnexpectedTypeException` 'PropertyAccessor requires a graph of objects or arrays to operate on error.

https://www.pivotaltracker.com/story/show/164729675