### PR TITLE
Fix sraa access on institution switcher pages

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -376,7 +376,7 @@
       </trans-unit>
       <trans-unit id="958288c6f1c589b8fa5875163ea436dafaa3711b" resname="ra.form.select_institution.label.institution">
         <source>ra.form.select_institution.label.institution</source>
-        <target>Institution</target>
+        <target>Select institution</target>
         <jms:reference-file line="37">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SelectInstitutionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc646760865688482dd10d1f7bf383e3cf68b349" resname="ra.form.start_vetting_procedure.enter_activation_code_here">

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -376,7 +376,7 @@
       </trans-unit>
       <trans-unit id="958288c6f1c589b8fa5875163ea436dafaa3711b" resname="ra.form.select_institution.label.institution">
         <source>ra.form.select_institution.label.institution</source>
-        <target>Instelling</target>
+        <target>Selecteer instelling</target>
         <jms:reference-file line="37">/../src/Surfnet/StepupRa/RaBundle/Form/Type/SelectInstitutionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc646760865688482dd10d1f7bf383e3cf68b349" resname="ra.form.start_vetting_procedure.enter_activation_code_here">

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaaController.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Controller;
 
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Surfnet\StepupRa\RaBundle\Service\InstitutionListingService;
 use Surfnet\StepupRa\RaBundle\Service\ProfileService;
 use Surfnet\StepupRa\RaBundle\Command\SelectInstitutionCommand;
 use Surfnet\StepupRa\RaBundle\Form\Type\SelectInstitutionType;
@@ -37,17 +38,17 @@ class RaaController extends Controller
         $identity = $this->getUser();
 
         $profile = $this->getProfileService()->findByIdentityId($identity->id);
-        $choices = $profile->getRaaInstitutions();
-        $institution = reset($choices);
+
+        if ($this->isGranted('ROLE_SRAA')) {
+            $institution = $identity->institution;
+            $choices = $this->getInstitutionListingService()->getAll();
+        } else {
+            $choices = $profile->getRaaInstitutions();
+            $institution = reset($choices);
+        }
 
         // Only show the form if more than one institutions where found.
         if (count($choices) > 1) {
-            // SRAA's are usually not RAA for other institutions as they already are SRAA. Show the institution config
-            // of the SRAAs SHO, and let her use the SRAA switcher in order to see config for different institutions.
-            if ($this->isGranted('ROLE_SRAA')) {
-                $institution = $identity->institution;
-            }
-
             $command = new SelectInstitutionCommand();
             $command->institution = $institution;
             $command->availableInstitutions = $choices;
@@ -95,5 +96,13 @@ class RaaController extends Controller
     private function getProfileService()
     {
         return $this->get('ra.service.profile');
+    }
+
+    /**
+     * @return InstitutionListingService
+     */
+    private function getInstitutionListingService()
+    {
+        return $this->get('ra.service.institution_listing');
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -254,8 +254,13 @@ services:
     ra.service.profile:
         class: Surfnet\StepupRa\RaBundle\Service\ProfileService
         arguments:
-          - "@surfnet_stepup_middleware_client.identity.service.profile"
-          - "@logger"
+            - "@surfnet_stepup_middleware_client.identity.service.profile"
+            - "@logger"
+
+    ra.service.institution_listing:
+        class: Surfnet\StepupRa\RaBundle\Service\InstitutionListingService
+        arguments:
+            - "@surfnet_stepup_middleware_client.identity.service.institution_listing"
 
     # Repositories
     ra.repository.vetting_procedure:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/js/stepup-ra.js
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/js/stepup-ra.js
@@ -188,5 +188,11 @@
             $('button#ra_search_ra_second_factors_export').hide();
         }
 
+        // Post sub institution switcher on change
+        $(document).on('change', '#select_institution_institution', function() {
+            var form = $(this).closest("form");
+            form.submit();
+        });
+
     });
 })(jQuery);

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -233,9 +233,22 @@ form[name="select_institution"] {
     div.row.horizontal {
         div.form-group {
             float: left;
+            width: 60%;
+
+            .control-label {
+                text-align: left;
+            }
         }
     }
 }
+
+#select_institution_select_and_apply {
+    display: block;
+}
+.js #select_institution_select_and_apply {
+    display: none
+}
+
 select[name="stepup_switch_locale[locale]"] {
     min-width: 150px;
 }

--- a/src/Surfnet/StepupRa/RaBundle/Service/InstitutionListingService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/InstitutionListingService.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Surfnet\StepupMiddlewareClientBundle\Identity\Service\InstitutionListingService as ApiInstitutionListingService;
+
+class InstitutionListingService
+{
+    /**
+     * @var ApiInstitutionListingService
+     */
+    private $institutionListingService;
+
+    /**
+     * @param ApiInstitutionListingService $institutionListingService
+     */
+    public function __construct(
+        ApiInstitutionListingService $institutionListingService
+    ) {
+        $this->institutionListingService = $institutionListingService;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAll()
+    {
+        $collection = $this->institutionListingService->getAll();
+        $listings = $collection->getElements();
+
+        $options = [];
+        foreach ($listings as $listing) {
+            $result[$listing->institution] = $listing->institution;
+        }
+
+        return $options;
+    }
+}


### PR DESCRIPTION
Sraa access was prevented from certain pages implementing the
institution switcher. That was happening because MW didn't
return institutions when fetching a profile from teh current user.
This is now handled by the InstitutionListingService which will
fetch all institutions.