### PR TITLE
Resolve floating issue for role-at-institution form group

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -254,15 +254,26 @@ select[name="stepup_switch_locale[locale]"] {
 }
 
 .role-at-institution {
-    position: relative;
+    display: flex;
     .form-group {
-        float: left;
-        @media (max-width: @screen-sm-min) {
-            float: none;
-        }
-        min-width: 175px;
+        margin: 0;
         select {
             min-width: 175px;
+        }
+        .control-label {
+            width: 20px;
+        }
+        &:first-child {
+            margin-left: -15px;
+        }
+    }
+
+    @media all and (-ms-high-contrast: none) {
+        /* IE10/11 specific layout tweak */
+        position: relative;
+        display: block;
+        .form-group {
+            float: left;
         }
     }
 }


### PR DESCRIPTION
The role at institution select lists are displayed in one row even
though the are two separate elements. The symfony form styling is
overridden in order to render them nicely together. For modern browsers,
flex layout is utilized. For IE10+11, a fallback is used based on the
previous solution that was in place.

See: https://www.pivotaltracker.com/story/show/165719957