### PR TITLE
Upgrade xmlseclibs to version 3.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,8 @@ branches:
     - master
     - develop
     - release/2.10
+
+addons:
+  apt:
+    packages:
+      - ant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
 ## 2.10.8
-**Improvement**
-* Install security updates
+This is a security release that will harden the application against CVE 2019-346
+ * Upgrade xmlseclibs to version 3.0.4 #226 
 
-# 2.10.7
-
+## 2.10.7
 **Features**
 * Allow filtering the RA candidate on institute #201
 * Add search support on the RA management page #200

--- a/composer.lock
+++ b/composer.lock
@@ -1950,23 +1950,21 @@
         },
         {
             "name": "robrichards/xmlseclibs",
-            "version": "3.0.1",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robrichards/xmlseclibs.git",
-                "reference": "d937712f70f93a584eb0299ccd87dc6374003781"
+                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/d937712f70f93a584eb0299ccd87dc6374003781",
-                "reference": "d937712f70f93a584eb0299ccd87dc6374003781",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/0a53d3c3aa87564910cae4ed01416441d3ae0db5",
+                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5",
                 "shasum": ""
             },
             "require": {
+                "ext-openssl": "*",
                 "php": ">= 5.4"
-            },
-            "suggest": {
-                "ext-openssl": "OpenSSL extension"
             },
             "type": "library",
             "autoload": {
@@ -1986,7 +1984,7 @@
                 "xml",
                 "xmldsig"
             ],
-            "time": "2017-08-31T09:27:07+00:00"
+            "time": "2019-11-05T11:44:22+00:00"
         },
         {
             "name": "sensio/distribution-bundle",


### PR DESCRIPTION
This change will apply the countermeasures to harden against CVE 2019-3465 and will effectively bump `robrichards/xmlseclibs` to version 3.0.4

This PR is targetted at Release 16 and should land in version 2.10.8