### PR TITLE
Improve button-group button alignment

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/AmendRegistrationAuthorityInformationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/AmendRegistrationAuthorityInformationType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -35,15 +36,27 @@ class AmendRegistrationAuthorityInformationType extends AbstractType
             ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.management.form.amend_ra_info.label.contact_information'
             ])
-            ->add('amend_ra_info', SubmitType::class, [
-                'label' => 'ra.management.form.amend_ra_info.label.amend_ra_info',
-                'attr' => ['class' => 'btn btn-primary pull-right']
-            ])
-            ->add('cancel', AnchorType::class, [
-                'label' => 'ra.management.form.amend_ra_info.label.cancel',
-                'route' => 'ra_management_manage',
-                'attr'  => ['class' => 'btn btn-link pull-right cancel']
-            ])
+            ->add(
+                $builder->create(
+                    'button-group',
+                    FormType::class,
+                    [
+                        'inherit_data' => true,
+                        // The empty label ensures the buttons are positioned correctly
+                        'label' => ' ',
+                        'widget_form_group_attr' => ['class' => 'form-group button-group'],
+                    ]
+                )
+                ->add('amend_ra_info', SubmitType::class, [
+                    'label' => 'ra.management.form.amend_ra_info.label.amend_ra_info',
+                    'attr' => ['class' => 'btn btn-primary pull-right']
+                ])
+                ->add('cancel', AnchorType::class, [
+                    'label' => 'ra.management.form.amend_ra_info.label.cancel',
+                    'route' => 'ra_management_manage',
+                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
+                ])
+            )
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaLocationType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,15 +39,27 @@ class ChangeRaLocationType extends AbstractType
             ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.management.form.change_ra.label.contact_information'
             ])
-            ->add('change_ra_location', SubmitType::class, [
-                'label' => 'ra.management.form.change_ra_location.label.change_ra_location',
-                'attr' => ['class' => 'btn btn-primary pull-right change-ra-location']
-            ])
-            ->add('cancel', AnchorType::class, [
-                'label' => 'ra.management.form.change_ra_location.label.cancel',
-                'route' => 'ra_locations_manage',
-                'attr' => ['class' => 'btn btn-link pull-right cancel'],
-            ])
+            ->add(
+                $builder->create(
+                    'button-group',
+                    FormType::class,
+                    [
+                        'inherit_data' => true,
+                        // The empty label ensures the buttons are positioned correctly
+                        'label' => ' ',
+                        'widget_form_group_attr' => ['class' => 'form-group button-group'],
+                    ]
+                )
+                ->add('change_ra_location', SubmitType::class, [
+                    'label' => 'ra.management.form.change_ra_location.label.change_ra_location',
+                    'attr' => ['class' => 'btn btn-primary pull-right change-ra-location']
+                ])
+                ->add('cancel', AnchorType::class, [
+                    'label' => 'ra.management.form.change_ra_location.label.cancel',
+                    'route' => 'ra_locations_manage',
+                    'attr' => ['class' => 'btn btn-link pull-right cancel'],
+                ])
+            )
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaRoleType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/ChangeRaRoleType.php
@@ -21,6 +21,7 @@ namespace Surfnet\StepupRa\RaBundle\Form\Type;
 use Surfnet\StepupRa\RaBundle\Form\Extension\RaRoleChoiceList;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -35,15 +36,29 @@ class ChangeRaRoleType extends AbstractType
                 'choices' => RaRoleChoiceList::create(),
                 'choices_as_values' => true,
             ])
-            ->add('create_ra', SubmitType::class, [
-                'label' => 'ra.management.form.change_ra_role.label.save',
-                'attr'  => ['class' => 'btn btn-primary pull-right change-ra-role']
-            ])
-            ->add('cancel', AnchorType::class, [
-                'label' => 'ra.management.form.create_ra.label.cancel',
-                'route' => 'ra_management_ra_candidate_search',
-                'attr'  => ['class' => 'btn btn-link pull-right cancel']
-            ]);
+
+            ->add(
+                $builder->create(
+                    'button-group',
+                    FormType::class,
+                    [
+                        'inherit_data' => true,
+                        // The empty label ensures the buttons are positioned correctly
+                        'label' => ' ',
+                        'widget_form_group_attr' => ['class' => 'form-group button-group'],
+                    ]
+                )
+                ->add('create_ra', SubmitType::class, [
+                    'label' => 'ra.management.form.change_ra_role.label.save',
+                    'attr'  => ['class' => 'btn btn-primary pull-right change-ra-role']
+                ])
+                ->add('cancel', AnchorType::class, [
+                    'label' => 'ra.management.form.create_ra.label.cancel',
+                    'route' => 'ra_management_ra_candidate_search',
+                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
+                ])
+            )
+        ;
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaLocationType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaLocationType.php
@@ -19,6 +19,7 @@
 namespace Surfnet\StepupRa\RaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,15 +39,27 @@ class CreateRaLocationType extends AbstractType
             ->add('contactInformation', TextareaType::class, [
                 'label' => 'ra.form.ra_create_ra_location.label.contact_information'
             ])
-            ->add('create_ra_location', SubmitType::class, [
-                'label' => 'ra.form.ra_create_ra_location.label.create_ra_location',
-                'attr' => ['class' => 'btn btn-primary pull-right create-ra-location']
-            ])
-            ->add('cancel', AnchorType::class, [
-                'label' => 'ra.form.ra_create_ra_location.label.cancel',
-                'route' => 'ra_locations_manage',
-                'attr'  => ['class' => 'btn btn-link pull-right cancel']
-            ])
+            ->add(
+                $builder->create(
+                    'button-group',
+                    FormType::class,
+                    [
+                        'inherit_data' => true,
+                        // The empty label ensures the buttons are positioned correctly
+                        'label' => ' ',
+                        'widget_form_group_attr' => ['class' => 'form-group button-group'],
+                    ]
+                )
+                ->add('create_ra_location', SubmitType::class, [
+                    'label' => 'ra.form.ra_create_ra_location.label.create_ra_location',
+                    'attr' => ['class' => 'btn btn-primary pull-right create-ra-location']
+                ])
+                ->add('cancel', AnchorType::class, [
+                    'label' => 'ra.form.ra_create_ra_location.label.cancel',
+                    'route' => 'ra_locations_manage',
+                    'attr'  => ['class' => 'btn btn-link pull-right cancel']
+                ])
+            )
         ;
     }
 

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/CreateRaType.php
@@ -52,7 +52,8 @@ class CreateRaType extends AbstractType
                     FormType::class,
                     [
                         'inherit_data' => true,
-                        'label' => false,
+                        // The empty label ensures the buttons are positioned correctly
+                        'label' => ' ',
                         'widget_form_group_attr' => ['class' => 'form-group button-group'],
                     ]
                 )

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php
@@ -81,7 +81,8 @@ class SearchRaSecondFactorsType extends AbstractType
                 FormType::class,
                 [
                     'inherit_data' => true,
-                    'label' => false,
+                    // The empty label ensures the buttons are positioned correctly
+                    'label' => ' ',
                     'widget_form_group_attr' => ['class' => 'form-group button-group'],
                 ]
             )

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -243,20 +243,6 @@ select[name="stepup_switch_locale[locale]"] {
     min-width: 150px;
 }
 
-//.role-at-institution {
-//    position: relative;
-//    .form-group {
-//        float: left;
-//        @media (max-width: @screen-sm-min) {
-//            float: none;
-//        }
-//        min-width: 175px;
-//        select {
-//            min-width: 175px;
-//        }
-//    }
-//}
-
 .role-at-institution {
     display: flex;
     .form-group {

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/less/style.less
@@ -160,19 +160,7 @@ select.form-control {
         input#ra_search_ra_second_factors_secondFactorId {
             max-width: 200px;
         }
-        button#ra_search_ra_second_factors_export {
-            margin-left: 0.5em;
-        }
-        div.button-group {
-            margin-left: 25%;
-            div.form-group {
-                margin-right: 14px;
-                float: left;
-                button:first-child {
-                    margin-left: 8px;
-                }
-            }
-        }
+
     }
     td.button-column {
         .audit-log, .revoke {
@@ -181,10 +169,9 @@ select.form-control {
     }
 }
 
-form[name="ra_management_create_ra"] {
+form {
     div.button-group {
         div {
-            left: 16%;
             margin-top: 0.5em;
 
             @media (max-width: @screen-sm-max) {
@@ -192,8 +179,11 @@ form[name="ra_management_create_ra"] {
             }
             div {
                 position: relative;
-                width: 110px;
+                padding-left: 15px;
                 float: left;
+            }
+            div.form-group {
+                margin-right: 1em;
             }
         }
     }


### PR DESCRIPTION
Buttons are aligned on the second column of the form field from left to right. This was agreed upon during the first development effor that touched alignment issues in this regard. The story this work hails from only mentions the change ra role and amend ra forms. Three other forms had similar button alginment issues. They have all been addressed in this commit.

Note that a app/console assetic:dump is required to enjoy these changes.

See: https://www.pivotaltracker.com/story/show/170487965