### PR TITLE
Remove filter from ra candidate search form

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Command/SearchRaCandidatesCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/SearchRaCandidatesCommand.php
@@ -79,9 +79,4 @@ class SearchRaCandidatesCommand
      * @var array
      */
     public $institutionFilterOptions;
-
-    /**
-     * @var array
-     */
-    public $raInstitutionFilterOptions;
 }

--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -126,7 +126,6 @@ class RaManagementController extends Controller
 
         // The options that will populate the institution filter choice list.
         $command->institutionFilterOptions = $raCandidateList->getFilterOption('institution');
-        $command->raInstitutionFilterOptions = $raCandidateList->getFilterOption('raInstitution');
 
         $form = $this->createForm(SearchRaCandidatesType::class, $command, ['method' => 'get']);
         $form->handleRequest($request);

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaCandidatesType.php
@@ -32,7 +32,6 @@ class SearchRaCandidatesType extends AbstractType
         /** @var $command SearchRaCandidatesCommand */
         $command = $builder->getData();
         $institutions = $command->institutionFilterOptions;
-        $raInstitutions = $command->raInstitutionFilterOptions;
 
         $builder
             ->add('name', null, [
@@ -44,11 +43,6 @@ class SearchRaCandidatesType extends AbstractType
             ->add('institution', ChoiceType::class, [
                 'label' => 'ra.form.ra_search_ra_candidates.label.institution',
                 'choices' => $institutions,
-                'required' => false,
-            ])
-            ->add('raInstitution', ChoiceType::class, [
-                'label' => 'ra.form.ra_search_ra_candidates.label.raInstitution',
-                'choices' => $raInstitutions,
                 'required' => false,
             ])
             ->add('search', SubmitType::class, [


### PR DESCRIPTION
The RA candidate selectlist filter was removed from the form. This
filter did not have much benefit for the user experience. And was
confusing as it seemingly behaved like the regular institution filter
(which previous to the middleware fix was broken).

See:
https://www.pivotaltracker.com/story/show/171512620
https://github.com/OpenConext/Stepup-Middleware/pull/297