### PR TITLE
Allow updating the location of an RA

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/RaManagementController.php
@@ -234,7 +234,7 @@ class RaManagementController extends Controller
 
         $command = new AmendRegistrationAuthorityInformationCommand();
         $command->identityId = $raListing->identityId;
-        $command->location = $this->getUser()->institution;
+        $command->location = $raListing->location;
         $command->contactInformation = $raListing->contactInformation;
         $command->institution = $raListing->raInstitution;
 


### PR DESCRIPTION
Use the location from the RA and do not set the current users' institution as location. Which would result in re-setting the user SHO as the RA location instead of the one set in the form.

https://www.pivotaltracker.com/story/show/171812783