### PR TITLE
Fix files not added to root of archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
     },
     "archive": {
         "exclude": [
-            "*",
             ".*",
             "*/Tests/*",
             "!/bin",

--- a/composer.json
+++ b/composer.json
@@ -77,8 +77,10 @@
     },
     "archive": {
         "exclude": [
+            "*",
             ".*",
             "*/Tests/*",
+            "!/component_info",
             "!/bin",
             "!/config",
             "!/public",


### PR DESCRIPTION
https://github.com/OpenConext/Stepup-Middleware/pull/314
I'm not shure why '*' was excluded, but it caused the new component_info was missing in the archive, and deploy failing.