### PR TITLE
WIP: Do not error when loa does not existing in vetting procedure

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingController.php
@@ -123,7 +123,7 @@ class VettingController extends Controller
             return ['form' => $form->createView()];
         }
 
-        if (!$this->getVettingService()->isLoaSufficientToStartProcedure($command)) {
+        if ($command->authorityLoa === null || !$this->getVettingService()->isLoaSufficientToStartProcedure($command)) {
             $this->addFlash('error', 'ra.form.start_vetting_procedure.loa_insufficient');
 
             $logger->notice('Cannot start new vetting procedure, Authority LoA is insufficient');


### PR DESCRIPTION
This is a workaround for a case that a LOA does not exist in the
SAML token. The code allows for a nullable loa in the StartVettingProcedureCommand
which will error when checking the required loa level. This changes
checks for existence of the loa and if not will stop the vetting procedure.

See issue: https://github.com/OpenConext/Stepup-RA/issues/246


Please do no merge this before investigating the real rootcause of the nullable LOA