### PR TITLE
Implement recovery token revocation

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2205,12 +2205,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "ebd1eebb1a6c443796987c17475c5705bfb5a915"
+                "reference": "f5556405e8d247dcbf98307504b8cdcb5e21e6f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/ebd1eebb1a6c443796987c17475c5705bfb5a915",
-                "reference": "ebd1eebb1a6c443796987c17475c5705bfb5a915",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/f5556405e8d247dcbf98307504b8cdcb5e21e6f1",
+                "reference": "f5556405e8d247dcbf98307504b8cdcb5e21e6f1",
                 "shasum": ""
             },
             "require": {
@@ -2262,7 +2262,7 @@
                 "source": "https://github.com/OpenConext/Stepup-Middleware-clientbundle/tree/feature/self-asserted-tokens",
                 "issues": "https://github.com/OpenConext/Stepup-Middleware-clientbundle/issues"
             },
-            "time": "2022-07-12T10:15:30+00:00"
+            "time": "2022-07-13T06:31:56+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/src/Surfnet/StepupRa/RaBundle/Command/RevokeRecoveryTokenCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/RevokeRecoveryTokenCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Command;
+
+class RevokeRecoveryTokenCommand
+{
+    /**
+     * @var string
+     */
+    public $recoveryTokenId;
+
+    /**
+     * @var string
+     */
+    public $identityId;
+
+    /**
+     * @var string
+     */
+    public $currentUserId;
+}

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/RevokeRecoveryTokenType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/RevokeRecoveryTokenType.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Form\Type;
+
+use Surfnet\StepupRa\RaBundle\Command\RevokeRecoveryTokenCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RevokeRecoveryTokenType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('recoveryTokenId', HiddenType::class)
+            ->add('identityId', HiddenType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => RevokeRecoveryTokenCommand::class,
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'ra_revoke_recovery_token';
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
@@ -51,7 +51,7 @@ ra_recovery_tokens_search:
 ra_recovery_tokens_revoke:
     path:     /recovery-tokens/revoke
     methods:  [POST]
-#    defaults: { _controller: SurfnetStepupRaRaBundle:RecoveryToken:revoke }
+    defaults: { _controller: SurfnetStepupRaRaBundle:RecoveryToken:revoke }
 
 ra_vetting_search:
     path:     /

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -248,6 +248,7 @@ services:
         arguments:
             - "@ra.service.command"
             - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\RecoveryTokenService'
+            - '@logger'
 
     # Repositories
     ra.repository.vetting_procedure:

--- a/src/Surfnet/StepupRa/RaBundle/Resources/public/js/stepup-ra.js
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/public/js/stepup-ra.js
@@ -54,28 +54,29 @@
             });
         });
 
+
         $('#revokeRecoveryTokenModal').on('show.bs.modal', function (event) {
             var button = $(event.relatedTarget),
                 data = button.data(),
-                sf = {
-                    id: data.sfid,
-                    identifier: data.sfidentifier,
-                    type: data.sftype,
-                    identityId: data.sfidentityid,
-                    name: data.sfname,
-                    email: data.sfemail
+                rt = {
+                    id: data.rtid,
+                    type: data.rttype,
+                    identityId: data.rtidentityid,
+                    name: data.rtname,
+                    institution: data.rtinstitution,
+                    email: data.rtemail
                 },
                 modal = $(this);
 
-            modal.find('.modal-body td.identifier').text(sf.identifier);
-            modal.find('.modal-body td.type').text(sf.type);
-            modal.find('.modal-body td.name').text(sf.name);
-            modal.find('.modal-body td.email').text(sf.email);
+            modal.find('.modal-body td.type').text(rt.type);
+            modal.find('.modal-body td.name').text(rt.name);
+            modal.find('.modal-body td.email').text(rt.email);
+            modal.find('.modal-body td.institution').text(rt.institution);
 
             modal.on('click', 'button.revoke', function (event) {
-                var form = $('form[name="ra_revoke_second_factor"]'),
-                    secondFactorIdInput = $('#ra_revoke_second_factor_secondFactorId'),
-                    identityIdInput = $('#ra_revoke_second_factor_identityId');
+                var form = $('form[name="ra_revoke_recovery_token"]'),
+                    identityIdInput = $('#ra_revoke_recovery_token_identityId'),
+                    recoveryTokenIdIdInput = $('#ra_revoke_recovery_token_recoveryTokenId');
 
                 modal.find('button').prop('disabled', true);
                 modal.on('hide.bs.modal', function (event) {
@@ -83,8 +84,8 @@
                     event.stopPropagation();
                 });
 
-                secondFactorIdInput.val(sf.id);
-                identityIdInput.val(sf.identityId);
+                identityIdInput.val(rt.identityId);
+                recoveryTokenIdIdInput.val(rt.id);
 
                 form.submit();
             });

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig
@@ -36,8 +36,9 @@
                             <td>{{ recoveryToken.status|trans }}</td>
                             <td class="button-column">
                                 {% if showRevoke %}
-                                <button class="btn btn-warning revoke" data-toggle="modal" data-target="#revocationModal"
+                                <button class="btn btn-warning revoke" data-toggle="modal" data-target="#revokeRecoveryTokenModal"
                                         data-rtid="{{ recoveryToken.recoveryTokenId }}"
+                                        data-rtidentityid="{{ recoveryToken.identityId }}"
                                         data-rttype="{{ recoveryToken.type|trans }}"
                                         data-rtname="{{ recoveryToken.name }}"
                                         data-rtemail="{{ recoveryToken.email }}"

--- a/templates/translations.twig
+++ b/templates/translations.twig
@@ -4,3 +4,7 @@
 {{ 'active'|trans }}
 {{ 'revoked'|trans }}
 {{ 'forgotten'|trans }}
+
+{# Recovery Token flash messages #}
+{{ 'ra.recovery_token.revocation.revoked'|trans }}
+{{ 'ra.recovery_token.revocation.could_not_revoke'|trans }}

--- a/translations/messages.en_GB.xliff
+++ b/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-12T13:32:07Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-07-13T08:43:07Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -353,7 +353,7 @@
         <source>ra.form.ra_search_ra_second_factors.label.status</source>
         <target>Status</target>
         <jms:reference-file line="58">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php</jms:reference-file>
-        <jms:reference-file line="67">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="53">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7bfd1b72b2e100569d5b328715abd728899c9043" resname="ra.form.ra_search_ra_second_factors.label.type">
         <source>ra.form.ra_search_ra_second_factors.label.type</source>
@@ -363,42 +363,42 @@
       <trans-unit id="3b5608b6c613a02efb9b09788f614843653d2575" resname="ra.form.ra_search_recovery_tokens.button.search">
         <source>ra.form.ra_search_recovery_tokens.button.search</source>
         <target state="translated">Search</target>
-        <jms:reference-file line="84">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="76">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9bfd7339ac97fb1a6ba1528c91db3c75e6b4c902" resname="ra.form.ra_search_recovery_tokens.choice.status.active">
         <source>ra.form.ra_search_recovery_tokens.choice.status.active</source>
         <target state="translated">Active</target>
-        <jms:reference-file line="69">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="55">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9a0ea5316ace920a3ad2248063193564fee8be7" resname="ra.form.ra_search_recovery_tokens.choice.status.forgotten">
         <source>ra.form.ra_search_recovery_tokens.choice.status.forgotten</source>
         <target state="translated">Forgotten</target>
-        <jms:reference-file line="71">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="57">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="775c2e58ffdd028f3951038351bcf2348c8adddd" resname="ra.form.ra_search_recovery_tokens.choice.status.revoked">
         <source>ra.form.ra_search_recovery_tokens.choice.status.revoked</source>
         <target state="translated">Removed</target>
-        <jms:reference-file line="70">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="56">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6863896675a0b8d57c06a0e6234293e4de257531" resname="ra.form.ra_search_recovery_tokens.label.email">
         <source>ra.form.ra_search_recovery_tokens.label.email</source>
         <target state="translated">Email</target>
-        <jms:reference-file line="54">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="46">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b66b80545adfeb008c71bbbb56d0d54a57a3ebae" resname="ra.form.ra_search_recovery_tokens.label.institution">
         <source>ra.form.ra_search_recovery_tokens.label.institution</source>
         <target state="translated">Institution</target>
-        <jms:reference-file line="61">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="63">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fcb04aec6047476e9658587356ee7e6e9cc4fe98" resname="ra.form.ra_search_recovery_tokens.label.name">
         <source>ra.form.ra_search_recovery_tokens.label.name</source>
         <target state="translated">Name</target>
-        <jms:reference-file line="45">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="34">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5565b5cb31a642c0f040791ff04552bd2bf5384f" resname="ra.form.ra_search_recovery_tokens.label.type">
         <source>ra.form.ra_search_recovery_tokens.label.type</source>
         <target state="translated">Type</target>
-        <jms:reference-file line="48">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="37">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b190a055ec0458747cdff543e6693c2433a6eb6b" resname="ra.form.ra_send_sms_challenge.button.send_challenge">
         <source>ra.form.ra_send_sms_challenge.button.send_challenge</source>
@@ -1068,51 +1068,61 @@
         <target>RA Location removed</target>
         <jms:reference-file line="228">/src/../src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php</jms:reference-file>
       </trans-unit>
+      <trans-unit id="b09ca683a805b5073bdd6188d77f22f11325f337" resname="ra.recovery_token.revocation.could_not_revoke">
+        <source>ra.recovery_token.revocation.could_not_revoke</source>
+        <target state="translated">The [Recovery token] could not be removed, please try again</target>
+        <jms:reference-file line="10">/src/../templates/translations.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8e163db19be077e7d5a6052fe096579447ba5d4a" resname="ra.recovery_token.revocation.modal.are_you_sure">
         <source>ra.recovery_token.revocation.modal.are_you_sure</source>
         <target state="needs-l10n">Are you sure you want to remove this [recovery token]?</target>
-        <jms:reference-file line="70">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="73">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37fda4b797990b89ab361954f2cb6decb1bbbde9" resname="ra.recovery_token.revocation.modal.cancel">
         <source>ra.recovery_token.revocation.modal.cancel</source>
         <target state="translated">Cancel</target>
-        <jms:reference-file line="92">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="95">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9330a24576485ca95f33f766c685bb8119ab6a83" resname="ra.recovery_token.revocation.modal.close">
         <source>ra.recovery_token.revocation.modal.close</source>
         <target state="translated">Close</target>
-        <jms:reference-file line="65">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="68">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3fd2015859ca223a1c14cc3fea1e957eb6886cc0" resname="ra.recovery_token.revocation.modal.confirm">
         <source>ra.recovery_token.revocation.modal.confirm</source>
         <target state="translated">Continue</target>
-        <jms:reference-file line="66">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
-        <jms:reference-file line="93">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="69">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="96">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77a6007facb8b0fcc795154386864265a7eea4bb" resname="ra.recovery_token.revocation.modal.rt_email">
         <source>ra.recovery_token.revocation.modal.rt_email</source>
         <target state="translated">Email</target>
-        <jms:reference-file line="82">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="85">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f57ace05c541b2e019b904c8b05954672061b994" resname="ra.recovery_token.revocation.modal.rt_institution">
         <source>ra.recovery_token.revocation.modal.rt_institution</source>
         <target state="translated">Institution</target>
-        <jms:reference-file line="86">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="89">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2c6a7db43d9d4a7aad04170a5a417fbc1b6e72d8" resname="ra.recovery_token.revocation.modal.rt_name">
         <source>ra.recovery_token.revocation.modal.rt_name</source>
         <target state="translated">Name</target>
-        <jms:reference-file line="78">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="81">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f85d924f4e1102aafe3157753f06f61a8928595f" resname="ra.recovery_token.revocation.modal.rt_type">
         <source>ra.recovery_token.revocation.modal.rt_type</source>
         <target state="translated">Type</target>
-        <jms:reference-file line="74">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="77">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="5b90c3c6b43668a13efa9de6a75c8707c3b616be" resname="ra.recovery_token.revocation.revoked">
+        <source>ra.recovery_token.revocation.revoked</source>
+        <target state="translated">The [Recovery token] was removed successfully.</target>
+        <jms:reference-file line="9">/src/../templates/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6474eabdc0538bed02d0343f8119de538b8ca353" resname="ra.recovery_token.revoke">
         <source>ra.recovery_token.revoke</source>
         <target state="translated">Remove</target>
-        <jms:reference-file line="45">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="68c7daafca87f421d8f0800e5f399066dc2dbe19" resname="ra.recovery_token.search.column.email">
         <source>ra.recovery_token.search.column.email</source>
@@ -1142,7 +1152,7 @@
       <trans-unit id="7cd6e960fe366ea7f42a30e2b9f37e8a51a971b7" resname="ra.recovery_token.search.text.no_recovery_tokens">
         <source>ra.recovery_token.search.text.no_recovery_tokens</source>
         <target state="needs-l10n">No [recovery tokens] found</target>
-        <jms:reference-file line="56">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="59">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4292d16545d77ea6d0d8dcc6b51dc067b49d216b" resname="ra.recovery_token.search.text.number_of_recovery_tokens">
         <source>ra.recovery_token.search.text.number_of_recovery_tokens</source>
@@ -1514,11 +1524,13 @@ The token is now activated and ready to be used.</target>
       <trans-unit id="e59d5dbfb886036d6a99e85bf857442d4ea4009c" resname="safe-store">
         <source>safe-store</source>
         <target state="needs-l10n">[Safe-store]</target>
+        <jms:reference-file line="40">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
         <jms:reference-file line="3">/src/../templates/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="83b04e2653917150804a1a71da678664e3e509b5" resname="sms">
         <source>sms</source>
         <target state="translated">SMS</target>
+        <jms:reference-file line="39">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
         <jms:reference-file line="2">/src/../templates/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c50aaca50072a446eab71327c6bfc5e5de8698f5" resname="stepup.error.authentication_error.description">

--- a/translations/messages.nl_NL.xliff
+++ b/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-12T13:32:04Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-07-13T08:43:04Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -353,7 +353,7 @@
         <source>ra.form.ra_search_ra_second_factors.label.status</source>
         <target>Status</target>
         <jms:reference-file line="58">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRaSecondFactorsType.php</jms:reference-file>
-        <jms:reference-file line="67">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="53">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7bfd1b72b2e100569d5b328715abd728899c9043" resname="ra.form.ra_search_ra_second_factors.label.type">
         <source>ra.form.ra_search_ra_second_factors.label.type</source>
@@ -363,42 +363,42 @@
       <trans-unit id="3b5608b6c613a02efb9b09788f614843653d2575" resname="ra.form.ra_search_recovery_tokens.button.search">
         <source>ra.form.ra_search_recovery_tokens.button.search</source>
         <target state="translated">Zoeken</target>
-        <jms:reference-file line="84">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="76">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9bfd7339ac97fb1a6ba1528c91db3c75e6b4c902" resname="ra.form.ra_search_recovery_tokens.choice.status.active">
         <source>ra.form.ra_search_recovery_tokens.choice.status.active</source>
         <target state="translated">Actief</target>
-        <jms:reference-file line="69">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="55">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9a0ea5316ace920a3ad2248063193564fee8be7" resname="ra.form.ra_search_recovery_tokens.choice.status.forgotten">
         <source>ra.form.ra_search_recovery_tokens.choice.status.forgotten</source>
         <target state="translated">Vergeten</target>
-        <jms:reference-file line="71">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="57">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="775c2e58ffdd028f3951038351bcf2348c8adddd" resname="ra.form.ra_search_recovery_tokens.choice.status.revoked">
         <source>ra.form.ra_search_recovery_tokens.choice.status.revoked</source>
         <target state="translated">Verwijderd</target>
-        <jms:reference-file line="70">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="56">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6863896675a0b8d57c06a0e6234293e4de257531" resname="ra.form.ra_search_recovery_tokens.label.email">
         <source>ra.form.ra_search_recovery_tokens.label.email</source>
         <target state="translated">E-mail</target>
-        <jms:reference-file line="54">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="46">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b66b80545adfeb008c71bbbb56d0d54a57a3ebae" resname="ra.form.ra_search_recovery_tokens.label.institution">
         <source>ra.form.ra_search_recovery_tokens.label.institution</source>
         <target state="translated">Instelling</target>
-        <jms:reference-file line="61">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="63">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fcb04aec6047476e9658587356ee7e6e9cc4fe98" resname="ra.form.ra_search_recovery_tokens.label.name">
         <source>ra.form.ra_search_recovery_tokens.label.name</source>
         <target state="translated">Naam</target>
-        <jms:reference-file line="45">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="34">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5565b5cb31a642c0f040791ff04552bd2bf5384f" resname="ra.form.ra_search_recovery_tokens.label.type">
         <source>ra.form.ra_search_recovery_tokens.label.type</source>
         <target state="translated">Type</target>
-        <jms:reference-file line="48">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
+        <jms:reference-file line="37">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b190a055ec0458747cdff543e6693c2433a6eb6b" resname="ra.form.ra_send_sms_challenge.button.send_challenge">
         <source>ra.form.ra_send_sms_challenge.button.send_challenge</source>
@@ -427,7 +427,7 @@
       </trans-unit>
       <trans-unit id="c6832a08b847d54411ebf61c59992cbe55a3e6fd" resname="ra.form.role_at_institution.label.institution">
         <source>ra.form.role_at_institution.label.institution</source>
-        <target state="translated">ra.form.role_at_institution.label.institution</target>
+        <target state="needs-l10n">ra.form.role_at_institution.label.institution</target>
         <jms:reference-file line="57">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/RoleAtInstitutionType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="95da352ffffc7357d377b648db7f01499ce9b588" resname="ra.form.select_institution.button.switch">
@@ -909,7 +909,7 @@
       </trans-unit>
       <trans-unit id="369112a278b7b4663a4ba31f26aa28a8167f12e4" resname="ra.menu.search_recovery_tokens">
         <source>ra.menu.search_recovery_tokens</source>
-        <target state="translated">[Recovery tokens]</target>
+        <target state="needs-l10n">[Recovery tokens]</target>
         <jms:reference-file line="66">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5f584865ad00e62914ac47108d14ee076f33c35e" resname="ra.profile.overview.authorizations">
@@ -1068,51 +1068,61 @@
         <target>RA-locatie verwijderd</target>
         <jms:reference-file line="228">/src/../src/Surfnet/StepupRa/RaBundle/Controller/RaLocationController.php</jms:reference-file>
       </trans-unit>
+      <trans-unit id="b09ca683a805b5073bdd6188d77f22f11325f337" resname="ra.recovery_token.revocation.could_not_revoke">
+        <source>ra.recovery_token.revocation.could_not_revoke</source>
+        <target state="translated">Het verwijderen van het [recovery token] is mislukt. Probeer het opnieuw.</target>
+        <jms:reference-file line="10">/src/../templates/translations.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8e163db19be077e7d5a6052fe096579447ba5d4a" resname="ra.recovery_token.revocation.modal.are_you_sure">
         <source>ra.recovery_token.revocation.modal.are_you_sure</source>
         <target state="translated">Weet je zeker dat je dit [recovery token] wilt verwijderen?</target>
-        <jms:reference-file line="70">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="73">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37fda4b797990b89ab361954f2cb6decb1bbbde9" resname="ra.recovery_token.revocation.modal.cancel">
         <source>ra.recovery_token.revocation.modal.cancel</source>
         <target state="translated">Terug</target>
-        <jms:reference-file line="92">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="95">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9330a24576485ca95f33f766c685bb8119ab6a83" resname="ra.recovery_token.revocation.modal.close">
         <source>ra.recovery_token.revocation.modal.close</source>
         <target state="translated">Sluiten</target>
-        <jms:reference-file line="65">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="68">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3fd2015859ca223a1c14cc3fea1e957eb6886cc0" resname="ra.recovery_token.revocation.modal.confirm">
         <source>ra.recovery_token.revocation.modal.confirm</source>
         <target state="translated">Verder</target>
-        <jms:reference-file line="66">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
-        <jms:reference-file line="93">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="69">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="96">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77a6007facb8b0fcc795154386864265a7eea4bb" resname="ra.recovery_token.revocation.modal.rt_email">
         <source>ra.recovery_token.revocation.modal.rt_email</source>
         <target state="translated">E-mail</target>
-        <jms:reference-file line="82">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="85">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f57ace05c541b2e019b904c8b05954672061b994" resname="ra.recovery_token.revocation.modal.rt_institution">
         <source>ra.recovery_token.revocation.modal.rt_institution</source>
         <target state="translated">Instelling</target>
-        <jms:reference-file line="86">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="89">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2c6a7db43d9d4a7aad04170a5a417fbc1b6e72d8" resname="ra.recovery_token.revocation.modal.rt_name">
         <source>ra.recovery_token.revocation.modal.rt_name</source>
         <target state="translated">Naam</target>
-        <jms:reference-file line="78">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="81">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f85d924f4e1102aafe3157753f06f61a8928595f" resname="ra.recovery_token.revocation.modal.rt_type">
         <source>ra.recovery_token.revocation.modal.rt_type</source>
         <target state="translated">Type</target>
-        <jms:reference-file line="74">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="77">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="5b90c3c6b43668a13efa9de6a75c8707c3b616be" resname="ra.recovery_token.revocation.revoked">
+        <source>ra.recovery_token.revocation.revoked</source>
+        <target state="translated">Het verwijderen van het [recovery token] is gelukt.</target>
+        <jms:reference-file line="9">/src/../templates/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6474eabdc0538bed02d0343f8119de538b8ca353" resname="ra.recovery_token.revoke">
         <source>ra.recovery_token.revoke</source>
         <target state="translated">Verwijderen</target>
-        <jms:reference-file line="45">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="68c7daafca87f421d8f0800e5f399066dc2dbe19" resname="ra.recovery_token.search.column.email">
         <source>ra.recovery_token.search.column.email</source>
@@ -1142,7 +1152,7 @@
       <trans-unit id="7cd6e960fe366ea7f42a30e2b9f37e8a51a971b7" resname="ra.recovery_token.search.text.no_recovery_tokens">
         <source>ra.recovery_token.search.text.no_recovery_tokens</source>
         <target state="translated">Er zijn geen [recovery tokens] gevonden</target>
-        <jms:reference-file line="56">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
+        <jms:reference-file line="59">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4292d16545d77ea6d0d8dcc6b51dc067b49d216b" resname="ra.recovery_token.search.text.number_of_recovery_tokens">
         <source>ra.recovery_token.search.text.number_of_recovery_tokens</source>
@@ -1151,7 +1161,7 @@
       </trans-unit>
       <trans-unit id="c6a8ca63fb65eca2a27a29e12c249f2426bf9bfa" resname="ra.recovery_token.search.title">
         <source>ra.recovery_token.search.title</source>
-        <target state="translated">[Recovery tokens]</target>
+        <target state="needs-l10n">[Recovery tokens]</target>
         <jms:reference-file line="3">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/recovery_token/search.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f12e743e43bca49fe86f99db331ded47fb88f1da" resname="ra.registration.sms.text.otp_requests_remaining">
@@ -1513,12 +1523,14 @@ Het token is nu geactiveerd en klaar voor gebruik.</target>
       </trans-unit>
       <trans-unit id="e59d5dbfb886036d6a99e85bf857442d4ea4009c" resname="safe-store">
         <source>safe-store</source>
-        <target state="translated">[Safe-store]</target>
+        <target state="needs-l10n">[Safe-store]</target>
+        <jms:reference-file line="40">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
         <jms:reference-file line="3">/src/../templates/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="83b04e2653917150804a1a71da678664e3e509b5" resname="sms">
         <source>sms</source>
         <target state="translated">SMS</target>
+        <jms:reference-file line="39">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/SearchRecoveryTokensType.php</jms:reference-file>
         <jms:reference-file line="2">/src/../templates/translations.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c50aaca50072a446eab71327c6bfc5e5de8698f5" resname="stepup.error.authentication_error.description">
@@ -1585,7 +1597,7 @@ Het token is nu geactiveerd en klaar voor gebruik.</target>
       </trans-unit>
       <trans-unit id="ac26c4ac73927d6fc18f0945262d2933fff5181b" resname="stepup.error.missing_required_attributes.title">
         <source>stepup.error.missing_required_attributes.title</source>
-        <target state="translated">stepup.error.missing_required_attributes.title</target>
+        <target state="needs-l10n">stepup.error.missing_required_attributes.title</target>
         <jms:reference-file line="133">/src/../vendor/surfnet/stepup-bundle/src/Controller/ExceptionController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b4809e818f782127b31392936e35593812543700" resname="stepup.error.page_not_found.text">

--- a/translations/validators.en_GB.xliff
+++ b/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-12T13:32:07Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-07-13T08:43:07Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -396,7 +396,7 @@
       </trans-unit>
       <trans-unit id="a051e522b28db694073f18072bef5467cdbdbd18" resname="ra.search_ra_candidates.actor_id.blank">
         <source>ra.search_ra_candidates.actor_id.blank</source>
-        <target state="new">ra.search_ra_candidates.actor_id.blank</target>
+        <target state="translated">Actor id can not be empty</target>
       </trans-unit>
       <trans-unit id="8cfc18f1009f0d1439707a6999cfdafca773c1a2" resname="ra.search_ra_candidates.actor_id.type">
         <source>ra.search_ra_candidates.actor_id.type</source>
@@ -420,27 +420,27 @@
       </trans-unit>
       <trans-unit id="2d9d40025c060c0652f8f4f26c8c57c3266318cc" resname="ra.search_ra_recovery_tokens.actor.blank">
         <source>ra.search_ra_recovery_tokens.actor.blank</source>
-        <target state="new">ra.search_ra_recovery_tokens.actor.blank</target>
+        <target state="translated">Actor id can not be empty</target>
       </trans-unit>
       <trans-unit id="d4b791fa7a94ab34468682dab9e997867c4dc861" resname="ra.search_ra_recovery_tokens.actor.type">
         <source>ra.search_ra_recovery_tokens.actor.type</source>
-        <target state="new">ra.search_ra_recovery_tokens.actor.type</target>
+        <target state="translated">Actor id must be of type string</target>
       </trans-unit>
       <trans-unit id="5449a408d035a742a1997e48835e89bfcd1d2ab7" resname="ra.search_ra_recovery_tokens.order_by.invalid_choice">
         <source>ra.search_ra_recovery_tokens.order_by.invalid_choice</source>
-        <target state="new">ra.search_ra_recovery_tokens.order_by.invalid_choice</target>
+        <target state="translated">Order by must be one of the valid options.</target>
       </trans-unit>
       <trans-unit id="d2aea3d6fed3cd7ef87311a4ea8abeacb63bc75f" resname="ra.search_ra_recovery_tokens.order_direction.invalid_choice">
         <source>ra.search_ra_recovery_tokens.order_direction.invalid_choice</source>
-        <target state="new">ra.search_ra_recovery_tokens.order_direction.invalid_choice</target>
+        <target state="translated">Order direction must be one of 'asc', 'desc'</target>
       </trans-unit>
       <trans-unit id="f74c0135130c3b019eba24ac1f4e625fbfea0b39" resname="ra.search_ra_recovery_tokens.page_number.greater_than_zero">
         <source>ra.search_ra_recovery_tokens.page_number.greater_than_zero</source>
-        <target state="new">ra.search_ra_recovery_tokens.page_number.greater_than_zero</target>
+        <target state="translated">The page number must be greater or equal to one</target>
       </trans-unit>
       <trans-unit id="8817e29ee436da4f64221ec81eb1d68806cef1fa" resname="ra.search_ra_recovery_tokens.page_number.type">
         <source>ra.search_ra_recovery_tokens.page_number.type</source>
-        <target state="new">ra.search_ra_recovery_tokens.page_number.type</target>
+        <target state="translated">Page number must be of type integer</target>
       </trans-unit>
       <trans-unit id="d64bbeccc3139dbd1700b23a16a4bb1dfd4dd518" resname="ra.search_ra_second_factors.actor.blank">
         <source>ra.search_ra_second_factors.actor.blank</source>
@@ -536,7 +536,7 @@
       </trans-unit>
       <trans-unit id="3d4708329f9161da18a0b3089e978c2d60175cbc" resname="stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string">
         <source>stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string</source>
-        <target state="new">stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string</target>
+        <target state="translated">Recovery token id for SMS proof of possession must be of type string</target>
       </trans-unit>
       <trans-unit id="e835d8b451f38086986c8e10ae614aacf5e5d8e8" resname="stepup.verify_possession_of_phone_command.second_factor_id.must_be_string">
         <source>stepup.verify_possession_of_phone_command.second_factor_id.must_be_string</source>

--- a/translations/validators.nl_NL.xliff
+++ b/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-12T13:32:04Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-07-13T08:43:04Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -8,11 +8,11 @@
     <body>
       <trans-unit id="e4360330d80b74e7def492078137d149364a8db1" resname="middleware_client.dto.configuration.allow_self_asserted_tokens.must_be_boolean">
         <source>middleware_client.dto.configuration.allow_self_asserted_tokens.must_be_boolean</source>
-        <target state="new">middleware_client.dto.configuration.allow_self_asserted_tokens.must_be_boolean</target>
+        <target state="translated">SAT option must be boolean</target>
       </trans-unit>
       <trans-unit id="9fe9614ee06100ffa9474b193d1aec7a4c1d1334" resname="middleware_client.dto.configuration.allowed_second_factors.must_be_array">
         <source>middleware_client.dto.configuration.allowed_second_factors.must_be_array</source>
-        <target state="new">middleware_client.dto.configuration.allowed_second_factors.must_be_array</target>
+        <target state="needs-translation"></target>
       </trans-unit>
       <trans-unit id="52a2dab4b580fea4ff59fc6a51bc2c0ba0f3b728" resname="middleware_client.dto.configuration.number_of_tokens_per_identity.must_be_integer">
         <source>middleware_client.dto.configuration.number_of_tokens_per_identity.must_be_integer</source>
@@ -421,27 +421,27 @@
       </trans-unit>
       <trans-unit id="2d9d40025c060c0652f8f4f26c8c57c3266318cc" resname="ra.search_ra_recovery_tokens.actor.blank">
         <source>ra.search_ra_recovery_tokens.actor.blank</source>
-        <target state="new">ra.search_ra_recovery_tokens.actor.blank</target>
+        <target state="translated">Recovery token actor must be set</target>
       </trans-unit>
       <trans-unit id="d4b791fa7a94ab34468682dab9e997867c4dc861" resname="ra.search_ra_recovery_tokens.actor.type">
         <source>ra.search_ra_recovery_tokens.actor.type</source>
-        <target state="new">ra.search_ra_recovery_tokens.actor.type</target>
+        <target state="translated">Recovery token actor must be of type string</target>
       </trans-unit>
       <trans-unit id="5449a408d035a742a1997e48835e89bfcd1d2ab7" resname="ra.search_ra_recovery_tokens.order_by.invalid_choice">
         <source>ra.search_ra_recovery_tokens.order_by.invalid_choice</source>
-        <target state="new">ra.search_ra_recovery_tokens.order_by.invalid_choice</target>
+        <target state="translated">Recovery token order by must be of one of the valid options</target>
       </trans-unit>
       <trans-unit id="d2aea3d6fed3cd7ef87311a4ea8abeacb63bc75f" resname="ra.search_ra_recovery_tokens.order_direction.invalid_choice">
         <source>ra.search_ra_recovery_tokens.order_direction.invalid_choice</source>
-        <target state="new">ra.search_ra_recovery_tokens.order_direction.invalid_choice</target>
+        <target state="translated">Order direction muste be one of 'asc' or 'desc'</target>
       </trans-unit>
       <trans-unit id="f74c0135130c3b019eba24ac1f4e625fbfea0b39" resname="ra.search_ra_recovery_tokens.page_number.greater_than_zero">
         <source>ra.search_ra_recovery_tokens.page_number.greater_than_zero</source>
-        <target state="new">ra.search_ra_recovery_tokens.page_number.greater_than_zero</target>
+        <target state="translated">Page number must be greater or equal to 1</target>
       </trans-unit>
       <trans-unit id="8817e29ee436da4f64221ec81eb1d68806cef1fa" resname="ra.search_ra_recovery_tokens.page_number.type">
         <source>ra.search_ra_recovery_tokens.page_number.type</source>
-        <target state="new">ra.search_ra_recovery_tokens.page_number.type</target>
+        <target state="translated">Page number must be of type string</target>
       </trans-unit>
       <trans-unit id="d64bbeccc3139dbd1700b23a16a4bb1dfd4dd518" resname="ra.search_ra_second_factors.actor.blank">
         <source>ra.search_ra_second_factors.actor.blank</source>
@@ -537,7 +537,7 @@
       </trans-unit>
       <trans-unit id="3d4708329f9161da18a0b3089e978c2d60175cbc" resname="stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string">
         <source>stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string</source>
-        <target state="new">stepup.verify_possession_of_phone_command.recovery_token_id.must_be_string</target>
+        <target state="translated">Proof of possession SMS recovery token, id must be of type string</target>
       </trans-unit>
       <trans-unit id="e835d8b451f38086986c8e10ae614aacf5e5d8e8" resname="stepup.verify_possession_of_phone_command.second_factor_id.must_be_string">
         <source>stepup.verify_possession_of_phone_command.second_factor_id.must_be_string</source>


### PR DESCRIPTION
This was a simple matter of calling the existing revoke endpoint on Middleware. Some new boilerplate was created to facilitate this in RA.

A form was added that is triggered by clicking 'continue' in the modal window. Some filthy JQuery code was copy pasted from the similar SF revocation solution. This code picks up the recovery token id, actor id and identity id (the one possessing the RT). And sets the values on the hidden revocation form.

A command was added that is filled with the form. And it contains the data required to revoke the token. This command is then posted onto the Middleware api (command endpoint) after being translated into a correct MW command in the client bundle.

Translations where updated.

https://www.pivotaltracker.com/story/show/181968091