### PR TITLE
Manage the institution specific vetting type hints

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2205,12 +2205,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-Middleware-clientbundle.git",
-                "reference": "997068be661f705e624d900cc376db775e387843"
+                "reference": "224e496da9b61997cddd035f4706e6ba89bf0474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/997068be661f705e624d900cc376db775e387843",
-                "reference": "997068be661f705e624d900cc376db775e387843",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-Middleware-clientbundle/zipball/224e496da9b61997cddd035f4706e6ba89bf0474",
+                "reference": "224e496da9b61997cddd035f4706e6ba89bf0474",
                 "shasum": ""
             },
             "require": {
@@ -2262,7 +2262,7 @@
                 "source": "https://github.com/OpenConext/Stepup-Middleware-clientbundle/tree/feature/self-asserted-tokens",
                 "issues": "https://github.com/OpenConext/Stepup-Middleware-clientbundle/issues"
             },
-            "time": "2022-07-13T13:22:01+00:00"
+            "time": "2022-07-26T09:50:54+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",

--- a/src/Surfnet/StepupRa/RaBundle/Command/VettingTypeHintCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/VettingTypeHintCommand.php
@@ -79,7 +79,7 @@ class VettingTypeHintCommand
         $this->assertValidLanguageInName($name);
         $locale = $this->extractLocaleFromFormFieldName($name);
         if ($this->__isset($name)) {
-            return $this->hints[$locale];
+            return $this->hints[$locale] ?: '';
         }
         return '';
     }

--- a/src/Surfnet/StepupRa/RaBundle/Command/VettingTypeHintCommand.php
+++ b/src/Surfnet/StepupRa/RaBundle/Command/VettingTypeHintCommand.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Command;
+
+use Surfnet\StepupRa\RaBundle\Exception\RuntimeException;
+use Surfnet\StepupRa\RaBundle\Form\Type\VettingTypeHintType;
+use function property_exists;
+
+/**
+ * This command is coupled to the VettingTypeHintType
+ *
+ * The vetting hint type creates a set of hint textareas that can be filled by
+ * a RA, filled with an institution specific hint on what type of vetting is
+ * advised.
+ *
+ * The form type will render a number of textareas, based on the locales configured
+ * on the application.
+ *
+ * See '%locales%' parameter in parameters.yaml
+ */
+class VettingTypeHintCommand
+{
+
+    /**
+     * @var string
+     */
+    public $identityId;
+
+    /**
+     * @var string
+     */
+    public $institution;
+
+    /**
+     * @var string[]
+     */
+    public $locales;
+
+    /**
+     * @var string[]
+     */
+    public $hints = [];
+
+    /**
+     * The translatable hints are set, using the PHP magic setter
+     */
+    public function __set(string $name, $value): void
+    {
+        if (property_exists($this, $name)) {
+            $this->{$name} = $value;
+            return;
+        }
+        $this->assertValidLanguageInName($name);
+        $locale = $this->extractLocaleFromFormFieldName($name);
+        $this->hints[$locale] = $value;
+    }
+
+    public function __get($name): string
+    {
+        if (property_exists($this, $name)) {
+            return $this->{$name};
+        }
+        $this->assertValidLanguageInName($name);
+        $locale = $this->extractLocaleFromFormFieldName($name);
+        if ($this->__isset($name)) {
+            return $this->hints[$locale];
+        }
+        return '';
+    }
+
+    public function __isset($name): bool
+    {
+        try {
+            $this->assertValidLanguageInName($name);
+            $locale = $this->extractLocaleFromFormFieldName($name);
+        } catch (RuntimeException $e) {
+            return false;
+        }
+        return array_key_exists($locale, $this->hints);
+    }
+
+    /**
+     * Based on the languages that are configured on the application eg: nl_NL or en_EN,..
+     * test if the passed parameter contains a valid language identifier.
+     */
+    private function assertValidLanguageInName($name)
+    {
+        $locale = $this->extractLocaleFromFormFieldName($name);
+        if (!in_array($locale, $this->locales, true)) {
+            throw new RuntimeException(
+                sprintf(
+                    'An invalid language ("%s") was rendered on the VettingTypeHintType form. ' .
+                    'Unable to process it in VettingTypeHintCommand. Configure it in the ' .
+                    'parameters.yaml or investigate why this rogue language ended up on the form.',
+                    $locale
+                )
+            );
+        }
+    }
+
+    private function extractLocaleFromFormFieldName(string $name): string
+    {
+        if (empty($this->locales)) {
+            throw new RuntimeException(
+                'No locales have been configured on the command yet, unable to process vetting type hints'
+            );
+        }
+
+        $prefix = VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX;
+        $matches = [];
+        preg_match('/'.$prefix.'(.*)/', $name, $matches);
+        if (!array_key_exists(1, $matches)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Unable to extract a locale from the form field name "%s". The field name prefix ' .
+                    'did not match the configured value "%s"',
+                    $name,
+                    $prefix
+                )
+            );
+        }
+        return $matches[1];
+    }
+
+    public function setHints(array $hints)
+    {
+        foreach ($hints as $hint) {
+            $this->hints[$hint['locale']] = $hint['hint'];
+        }
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Controller/VettingTypeHintController.php
+++ b/src/Surfnet/StepupRa/RaBundle/Controller/VettingTypeHintController.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Controller;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Surfnet\StepupRa\RaBundle\Command\VettingTypeHintCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\VettingTypeHintType;
+use Surfnet\StepupRa\RaBundle\Command\SelectInstitutionCommand;
+use Surfnet\StepupRa\RaBundle\Form\Type\SelectInstitutionType;
+use Surfnet\StepupRa\RaBundle\Service\InstitutionListingService;
+use Surfnet\StepupRa\RaBundle\Service\ProfileService;
+use Surfnet\StepupRa\RaBundle\Service\VettingTypeHintService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class VettingTypeHintController extends Controller
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ProfileService
+     */
+    private $profileService;
+
+    /**
+     * @var VettingTypeHintService
+     */
+    private $vettingTypeHintService;
+
+    /**
+     * @var InstitutionListingService
+     */
+    private $institutionListingService;
+
+    /**
+     * @var string[]
+     */
+    private $locales;
+
+    public function __construct(
+        LoggerInterface $logger,
+        InstitutionListingService $institutionListingService,
+        ProfileService $profileService,
+        VettingTypeHintService $vettingTypeHintService,
+        array $locales
+    ) {
+        $this->institutionListingService = $institutionListingService;
+        $this->profileService = $profileService;
+        $this->vettingTypeHintService = $vettingTypeHintService;
+        $this->locales = $locales;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Given the two forms being handled in this action, cc is higher.
+     */
+    public function vettingTypeHintAction(Request $request)
+    {
+        $this->denyAccessUnlessGranted(['ROLE_RAA', 'ROLE_SRAA']);
+
+        /** @var Identity $identity */
+        $identity = $this->getUser();
+
+        $profile = $this->profileService->findByIdentityId($identity->id);
+
+        if ($this->isGranted('ROLE_SRAA')) {
+            $institution =  $request->query->get('institution', $identity->institution);
+            $choices = $this->institutionListingService->getAll();
+        } elseif ($request->query->has('institution')) {
+            $choices = $profile->getRaaInstitutions();
+            $institution = $request->query->get('institution');
+        } else {
+            $choices = $profile->getRaaInstitutions();
+            $institution = reset($choices);
+        }
+
+        // Only show the form if more than one institution where found.
+        if (count($choices) > 1) {
+            $selectInstitutionCommand = new SelectInstitutionCommand();
+            $selectInstitutionCommand->institution = $institution;
+            $selectInstitutionCommand->availableInstitutions = $choices;
+
+            $form = $this->createForm(SelectInstitutionType::class, $selectInstitutionCommand);
+            $form->handleRequest($request);
+
+            if ($form->isSubmitted() && $form->isValid()) {
+                $institution = $selectInstitutionCommand->institution;
+            }
+        }
+
+        $command = new VettingTypeHintCommand();
+        $command->institution = $institution;
+        $command->identityId = $identity->id;
+        $command->locales = $this->locales;
+        $hints = $this->vettingTypeHintService->findBy($institution);
+        if ($hints) {
+            $command->setHints($hints->hints);
+        }
+        $hintForm = $this->createForm(VettingTypeHintType::class, $command);
+        $hintForm->handleRequest($request);
+
+        if ($hintForm->isSubmitted() && $hintForm->isValid()) {
+            $this->logger->debug('Vetting type hint form submitted, start processing command');
+
+            $success = $this->vettingTypeHintService->save($command);
+
+            if ($success) {
+                $this->addFlash('success', 'ra.vetting_type_hint.success');
+            } else {
+                $this->logger->debug('Vetting type hint saving failed, adding error to form');
+                $this->addFlash('error', 'ra.vetting_type_hint.error');
+            }
+        }
+
+        return $this->render(
+            '@SurfnetStepupRaRa/vetting_type_hint/overview.html.twig',
+            [
+                'form' => isset($form) ? $form->createView() : null,
+                'hintForm' => $hintForm->createView(),
+                'institution' => $institution,
+            ]
+        );
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php
@@ -39,11 +39,13 @@ class VettingTypeHintType extends AbstractType
                     TextareaType::class,
                     [
                         'label' => $locale,
+                        'required' => false,
                     ]
                 );
         }
         $builder
-            ->add('institution',
+            ->add(
+                'institution',
                 HiddenType::class
             )
             ->add(

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Form\Type;
+
+use Surfnet\StepupRa\RaBundle\Command\VettingTypeHintCommand;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class VettingTypeHintType extends AbstractType
+{
+    public const HINT_TEXTAREA_NAME_PREFIX = 'vetting_type_hint_';
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        foreach ($builder->getData()->locales as $locale) {
+            $builder
+                ->add(
+                    self::HINT_TEXTAREA_NAME_PREFIX . $locale,
+                    TextareaType::class,
+                    [
+                        'label' => 'ra.form.vetting_type_hint.label.hint' . $locale,
+                    ]
+                );
+        }
+        $builder
+            ->add('institution',
+                HiddenType::class
+            )
+            ->add(
+                'continue',
+                SubmitType::class,
+                [
+                    'label' => 'ra.form.vetting_type_hint.button.continue',
+                    'attr' => ['class' => 'btn btn-primary pull-right'],
+                ]
+            );
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => VettingTypeHintCommand::class,
+            ]
+        );
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'vetting_type_hint';
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php
@@ -38,7 +38,7 @@ class VettingTypeHintType extends AbstractType
                     self::HINT_TEXTAREA_NAME_PREFIX . $locale,
                     TextareaType::class,
                     [
-                        'label' => 'ra.form.vetting_type_hint.label.hint' . $locale,
+                        'label' => $locale,
                     ]
                 );
         }

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/routing.yml
@@ -144,6 +144,12 @@ institution-configuration:
     defaults:
         _controller: SurfnetStepupRaRaBundle:Raa:institutionConfiguration
 
+vetting_type_hint:
+    path: /vetting-type-hint
+    methods: [GET, POST]
+    defaults:
+        _controller: SurfnetStepupRaRaBundle:VettingTypeHint:vettingTypeHint
+
 ra_switch_locale:
     path:     /switch-locale
     methods:  [POST]

--- a/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/config/services.yml
@@ -250,6 +250,12 @@ services:
             - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\RecoveryTokenService'
             - '@logger'
 
+    Surfnet\StepupRa\RaBundle\Service\VettingTypeHintService:
+        arguments:
+            - '@ra.service.command'
+            - '@Surfnet\StepupMiddlewareClientBundle\Identity\Service\VettingTypeHintService'
+            - '@logger'
+
     # Repositories
     ra.repository.vetting_procedure:
         class: Surfnet\StepupRa\RaBundle\Repository\SessionVettingProcedureRepository
@@ -306,4 +312,13 @@ services:
             - '@Knp\Component\Pager\PaginatorInterface'
             - '@security.token_storage'
             - "@logger"
+        tags: ['controller.service_arguments']
+
+    Surfnet\StepupRa\RaBundle\Controller\VettingTypeHintController:
+        arguments:
+            - '@logger'
+            - '@ra.service.institution_listing'
+            - '@ra.service.profile'
+            - '@Surfnet\StepupRa\RaBundle\Service\VettingTypeHintService'
+            - '%locales%'
         tags: ['controller.service_arguments']

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig
@@ -81,3 +81,7 @@
 {# Recovery Token flash messages #}
 {{ 'ra.recovery_token.revocation.revoked'|trans }}
 {{ 'ra.recovery_token.revocation.could_not_revoke'|trans }}
+
+{# Vetting type hint flash messages #}
+{{ 'ra.vetting_type_hint.success'|trans }}
+{{ 'ra.vetting_type_hint.error'|trans  }}

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig
@@ -85,3 +85,7 @@
 {# Vetting type hint flash messages #}
 {{ 'ra.vetting_type_hint.success'|trans }}
 {{ 'ra.vetting_type_hint.error'|trans  }}
+
+{# Locale translations #}
+{{ 'nl_NL'|trans }}
+{{ 'en_GB'|trans }}

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig
@@ -11,7 +11,7 @@
 
     <div class="row">
         <div class="col-sm-12">
-            <h3>{{ 'ra.vetting_type_hint.subtitle'|trans({'%name%': institution}) }}</h3>
+            <h3>{{ 'ra.vetting_type_hint.subtitle'|trans({'%institution%': institution}) }}</h3>
         </div>
     </div>
 

--- a/src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig
+++ b/src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig
@@ -1,0 +1,23 @@
+{% extends 'base.html.twig' %}
+
+{% block page_title %}{{ 'ra.vetting_type_hint.title'|trans }}{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-sm-12" >
+            {% include 'SurfnetStepupRaRaBundle:partial:language_switcher.html.twig' with {'form': form} only %}
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <h3>{{ 'ra.vetting_type_hint.subtitle'|trans({'%name%': institution}) }}</h3>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            {{ form(hintForm) }}
+        </div>
+    </div>
+{% endblock content %}

--- a/src/Surfnet/StepupRa/RaBundle/Service/GlobalViewParameters.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/GlobalViewParameters.php
@@ -59,4 +59,12 @@ final class GlobalViewParameters
     {
         return $this->supportUrl[$this->translator->getLocale()];
     }
+
+    /**
+     * @return string[]
+     */
+    public function getLocales(): array
+    {
+        return $this->locales;
+    }
 }

--- a/src/Surfnet/StepupRa/RaBundle/Service/VettingTypeHintService.php
+++ b/src/Surfnet/StepupRa/RaBundle/Service/VettingTypeHintService.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupMiddlewareClient\Identity\Dto\VettingTypeHint;
+use Surfnet\StepupMiddlewareClientBundle\Exception\NotFoundException;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Command\SaveVettingTypeHintCommand;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Service\VettingTypeHintService as LibraryVettingTypeHintService;
+use Surfnet\StepupRa\RaBundle\Command\VettingTypeHintCommand;
+
+class VettingTypeHintService
+{
+    /**
+     * @var CommandService
+     */
+    private $commandService;
+
+    /**
+     * @var LibraryVettingTypeHintService
+     */
+    private $service;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        CommandService $commandService,
+        LibraryVettingTypeHintService $vettingTypeHintService,
+        LoggerInterface $logger
+    ) {
+        $this->commandService = $commandService;
+        $this->service = $vettingTypeHintService;
+        $this->logger = $logger;
+    }
+
+    public function save(VettingTypeHintCommand $command)
+    {
+        $middlewareCommand = new SaveVettingTypeHintCommand();
+        $middlewareCommand->identityId = $command->identityId;
+        $middlewareCommand->institution = $command->institution;
+        $middlewareCommand->hints = $command->hints;
+
+        $result = $this->commandService->execute($middlewareCommand);
+
+        if (!$result->isSuccessful()) {
+            $this->logger->critical(sprintf(
+                'Saving of the vetting type hint for institution "%s" by user "%s" failed: "%s"',
+                $middlewareCommand->institution,
+                $command->identityId,
+                implode(", ", $result->getErrors())
+            ));
+        }
+
+        return $result->isSuccessful();
+    }
+
+    public function findBy(string $institution): ?VettingTypeHint
+    {
+        try {
+            return $this->service->findOne($institution);
+        } catch (NotFoundException $e) {
+            return null;
+        }
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Command/VettingTypeHintCommandTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Command/VettingTypeHintCommandTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupRa\RaBundle\Command\VettingTypeHintCommand;
+use Surfnet\StepupRa\RaBundle\Exception\RuntimeException;
+use Surfnet\StepupRa\RaBundle\Form\Type\VettingTypeHintType;
+
+/**
+ * Given the use of the magic getters and setters this command is
+ * covered in extra tests. Hopefully demystifying the magic factor.
+ */
+class VettingTypeHintCommandTest extends TestCase
+{
+    public function test_setting_hints_is_allowed()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+        $command->__set(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'nl_NL', 'foobar');
+        $command->__set(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_GB', 'foobar');
+        $expectedData = [
+            'nl_NL' => 'foobar',
+            'en_GB' => 'foobar',
+        ];
+
+        $this->assertEquals($expectedData, $command->hints);
+    }
+
+    public function test_empty_hints_are_allowed()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+        $command->__set(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'nl_NL', '');
+        $command->__set(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_GB', '');
+        $expectedData = [
+            'nl_NL' => '',
+            'en_GB' => '',
+        ];
+
+        $this->assertEquals($expectedData, $command->hints);
+    }
+
+    public function test_invalid_locales_are_not_allowed()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('An invalid language ("en_US") was rendered on the VettingTypeHintType form. Unable to process it in VettingTypeHintCommand. Configure it in the parameters.yaml or investigate why this rogue language ended up on the form.');
+        $command->__set(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_US', 'foobar');
+    }
+
+    public function test_invalid_form_field_name_prefix_is_not_allowed()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to extract a locale from the form field name "sad_prefix_en_GB". The field name prefix did not match the configured value "vetting_type_hint_');
+        $command->__set('sad_prefix_en_GB', 'foobar');
+    }
+
+    public function test_invalid_when_no_locales_configured()
+    {
+        $command = new VettingTypeHintCommand();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No locales have been configured on the command yet, unable to process vetting type hints');
+        $command->__set(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_GB', '');
+    }
+
+    public function test_get_hint()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+        $command->hints = [
+            'nl_NL' => 'foobar',
+            'en_GB' => 'foobar',
+        ];
+
+        $this->assertEquals('foobar', $command->__get(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'nl_NL'));
+        $this->assertEquals('foobar', $command->__get(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_GB'));
+    }
+
+    public function test_get_hint_not_set_yields_empty_string()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+        $command->hints = [
+            'en_GB' => 'foobar',
+        ];
+
+        $this->assertEquals('', $command->__get(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'nl_NL'));
+        $this->assertEquals('foobar', $command->__get(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_GB'));
+    }
+
+    public function test_get_must_use_existing_prefix()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+        $command->hints = [
+            'en_GB' => 'foobar',
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to extract a locale from the form field name "sad_prefix_nl_NL". The field name prefix did not match the configured value "vetting_type_hint_"');
+        $command->__get('sad_prefix_nl_NL');
+    }
+
+    public function test_isset_hint()
+    {
+        $command = new VettingTypeHintCommand();
+        $command->locales = [0 => "nl_NL", 1 => "en_GB"];
+        $command->hints = [
+            'nl_NL' => 'foobar',
+            'en_GB' => 'foobar',
+        ];
+
+        $this->assertTrue($command->__isset(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'nl_NL'));
+        $this->assertTrue($command->__isset(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_GB'));
+        $this->assertFalse($command->__isset(VettingTypeHintType::HINT_TEXTAREA_NAME_PREFIX . 'en_US'));
+        $this->assertFalse($command->__isset('sad_prefix_en_US'));
+        $this->assertFalse($command->__isset(''));
+        $this->assertFalse($command->__isset(false));
+        $this->assertFalse($command->__isset('nl_NL'));
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -82,6 +82,11 @@
                                         <a href="{{ path('institution-configuration') }}">{{ 'ra.menu.institution-configuration'|trans }}</a>
                                     </li>
                                 {% endif %}
+                                {% if is_granted('ROLE_RAA') or is_granted('ROLE_SRAA') %}
+                                    <li role="presentation"{% if app.request.attributes.get('_route') starts with 'vetting_type_hint' %} class="active"{% endif %}>
+                                        <a href="{{ path('vetting_type_hint') }}">{{ 'ra.menu.vetting-type-hint'|trans }}</a>
+                                    </li>
+                                {% endif %}
 
                                 <li role="presentation"{% if app.request.attributes.get('_route') == 'ra_profile' %} class="active"{% endif %}>
                                     <a href="{{ path('ra_profile') }}">{{ 'ra.menu.ra_profile'|trans }}</a>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -78,13 +78,14 @@
                                 {% endif %}
 
                                 {% if is_granted('ROLE_RAA') or is_granted('ROLE_SRAA') %}
-                                    <li role="presentation"{% if app.request.attributes.get('_route') starts with 'institution-configuration' %} class="active"{% endif %}>
-                                        <a href="{{ path('institution-configuration') }}">{{ 'ra.menu.institution-configuration'|trans }}</a>
-                                    </li>
-                                {% endif %}
-                                {% if is_granted('ROLE_RAA') or is_granted('ROLE_SRAA') %}
                                     <li role="presentation"{% if app.request.attributes.get('_route') starts with 'vetting_type_hint' %} class="active"{% endif %}>
                                         <a href="{{ path('vetting_type_hint') }}">{{ 'ra.menu.vetting-type-hint'|trans }}</a>
+                                    </li>
+                                {% endif %}
+
+                                {% if is_granted('ROLE_RAA') or is_granted('ROLE_SRAA') %}
+                                    <li role="presentation"{% if app.request.attributes.get('_route') starts with 'institution-configuration' %} class="active"{% endif %}>
+                                        <a href="{{ path('institution-configuration') }}">{{ 'ra.menu.institution-configuration'|trans }}</a>
                                     </li>
                                 {% endif %}
 

--- a/translations/messages.en_GB.xliff
+++ b/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-13T15:22:45Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-07-26T15:44:24Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -30,12 +30,17 @@
       <trans-unit id="ff6230b38fe127145d864f4d4920ceb4d857af18" resname="button.logout">
         <source>button.logout</source>
         <target>Sign out</target>
-        <jms:reference-file line="93">/src/../templates/base.html.twig</jms:reference-file>
+        <jms:reference-file line="98">/src/../templates/base.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="4536d3e30c30ee352fda7e275bb682661cc32585" resname="en_GB">
+        <source>en_GB</source>
+        <target state="translated">English</target>
+        <jms:reference-file line="91">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5f1e0c5b2426bfd27630e1a79ced536d4ef05d10" resname="footer.documentation">
         <source>footer.documentation</source>
         <target>Manual</target>
-        <jms:reference-file line="140">/src/../templates/base.html.twig</jms:reference-file>
+        <jms:reference-file line="145">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b70686c582e1b6a0d8084f0b51c12df750a43ae8" resname="forgotten">
         <source>forgotten</source>
@@ -51,6 +56,11 @@
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
         <jms:reference-file line="3">/src/../vendor/surfnet/stepup-bundle/src/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="c2a655f18ad648ae4de40dd62ccb9103d6b52a8d" resname="nl_NL">
+        <source>nl_NL</source>
+        <target state="translated">Dutch</target>
+        <jms:reference-file line="90">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb2b9eca64fdf06848a11b0636ff4e92ac288d06" resname="ra">
         <source>ra</source>
@@ -508,6 +518,11 @@
         <target>Verify identity</target>
         <jms:reference-file line="45">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php</jms:reference-file>
       </trans-unit>
+      <trans-unit id="cd1693a1f3fe68e4d10ee970ea968383e8995955" resname="ra.form.vetting_type_hint.button.continue">
+        <source>ra.form.vetting_type_hint.button.continue</source>
+        <target>Save</target>
+        <jms:reference-file line="53">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="17ab744355f1655994692471da5d40bebb69b116" resname="ra.institution_configuration.all_second_factors_enabled">
         <source>ra.institution_configuration.all_second_factors_enabled</source>
         <target>All enabled tokens are available</target>
@@ -926,7 +941,7 @@
       <trans-unit id="3e81619fb5ba21daeb0d44b21d6e13071f33cd74" resname="ra.menu.ra_profile">
         <source>ra.menu.ra_profile</source>
         <target>My profile</target>
-        <jms:reference-file line="87">/src/../templates/base.html.twig</jms:reference-file>
+        <jms:reference-file line="92">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d6a9d74b9561d924dc4411c3ceebc63a01c83ae" resname="ra.menu.registration">
         <source>ra.menu.registration</source>
@@ -942,6 +957,11 @@
         <source>ra.menu.search_recovery_tokens</source>
         <target state="needs-l10n">[Recovery tokens]</target>
         <jms:reference-file line="66">/src/../templates/base.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ccf5f7d17e35ed6fd11aad7f781786f7e864d5e5" resname="ra.menu.vetting-type-hint">
+        <source>ra.menu.vetting-type-hint</source>
+        <target state="translated">[Vetting type hint]</target>
+        <jms:reference-file line="87">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5f584865ad00e62914ac47108d14ee076f33c35e" resname="ra.profile.overview.authorizations">
         <source>ra.profile.overview.authorizations</source>
@@ -1449,7 +1469,7 @@
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
         <source>ra.vetting.sms.challenge_body</source>
         <target>Your code: %challenge%</target>
-        <jms:reference-file line="242">/src/../src/Surfnet/StepupRa/RaBundle/Service/VettingService.php</jms:reference-file>
+        <jms:reference-file line="247">/src/../src/Surfnet/StepupRa/RaBundle/Service/VettingService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6d55aa46fb97f555148f92291a878be8ed732361" resname="ra.vetting.sms.prove_possession.title.page">
         <source>ra.vetting.sms.prove_possession.title.page</source>
@@ -1542,6 +1562,26 @@ The token is now activated and ready to be used.</target>
         <source>ra.vetting.yubikey.text.press_once_form_auto_submitted</source>
         <target>Press and hold the button on the personal Yubikey of the user once; a OTP will be generated in the field below.</target>
         <jms:reference-file line="17">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/vetting/yubikey/verify.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="aeaa50cfa81a57a14d0bcdb5179bf1fdb528a09e" resname="ra.vetting_type_hint.error">
+        <source>ra.vetting_type_hint.error</source>
+        <target state="translated">Saving the [vetting type hints] failed, please try again</target>
+        <jms:reference-file line="87">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="503e7024cbbeed07de169176e2e34729e2912693" resname="ra.vetting_type_hint.subtitle">
+        <source>ra.vetting_type_hint.subtitle</source>
+        <target state="translated">[Vetting type hints of] %institution%</target>
+        <jms:reference-file line="14">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9e3439b0a5b23046bd4e327b2a802446ab119d3c" resname="ra.vetting_type_hint.success">
+        <source>ra.vetting_type_hint.success</source>
+        <target state="translated">Saving of the [vetting type hint] was successful</target>
+        <jms:reference-file line="86">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="13411e66cc269e4b4517d14f54a8999680cb5a3e" resname="ra.vetting_type_hint.title">
+        <source>ra.vetting_type_hint.title</source>
+        <target state="translated">[Vetting type hints]</target>
+        <jms:reference-file line="3">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="21ae742a4f478c0afe9accf5d448335bf530a4f9" resname="raa">
         <source>raa</source>

--- a/translations/messages.nl_NL.xliff
+++ b/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-13T15:22:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-07-26T15:44:21Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -30,12 +30,17 @@
       <trans-unit id="ff6230b38fe127145d864f4d4920ceb4d857af18" resname="button.logout">
         <source>button.logout</source>
         <target>Uitloggen</target>
-        <jms:reference-file line="93">/src/../templates/base.html.twig</jms:reference-file>
+        <jms:reference-file line="98">/src/../templates/base.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="4536d3e30c30ee352fda7e275bb682661cc32585" resname="en_GB">
+        <source>en_GB</source>
+        <target state="translated">Engels</target>
+        <jms:reference-file line="91">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5f1e0c5b2426bfd27630e1a79ced536d4ef05d10" resname="footer.documentation">
         <source>footer.documentation</source>
         <target>Handleiding</target>
-        <jms:reference-file line="140">/src/../templates/base.html.twig</jms:reference-file>
+        <jms:reference-file line="145">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b70686c582e1b6a0d8084f0b51c12df750a43ae8" resname="forgotten">
         <source>forgotten</source>
@@ -51,6 +56,11 @@
         <source>locale.nl_NL</source>
         <target>Nederlands</target>
         <jms:reference-file line="3">/src/../vendor/surfnet/stepup-bundle/src/Resources/views/translations.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="c2a655f18ad648ae4de40dd62ccb9103d6b52a8d" resname="nl_NL">
+        <source>nl_NL</source>
+        <target state="translated">Nederlands</target>
+        <jms:reference-file line="90">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb2b9eca64fdf06848a11b0636ff4e92ac288d06" resname="ra">
         <source>ra</source>
@@ -508,6 +518,11 @@
         <target>Verifieer identiteit</target>
         <jms:reference-file line="45">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php</jms:reference-file>
       </trans-unit>
+      <trans-unit id="cd1693a1f3fe68e4d10ee970ea968383e8995955" resname="ra.form.vetting_type_hint.button.continue">
+        <source>ra.form.vetting_type_hint.button.continue</source>
+        <target state="translated">Opslaan</target>
+        <jms:reference-file line="53">/src/../src/Surfnet/StepupRa/RaBundle/Form/Type/VettingTypeHintType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="17ab744355f1655994692471da5d40bebb69b116" resname="ra.institution_configuration.all_second_factors_enabled">
         <source>ra.institution_configuration.all_second_factors_enabled</source>
         <target>Alle beschikbare tokens zijn toegestaan</target>
@@ -926,7 +941,7 @@
       <trans-unit id="3e81619fb5ba21daeb0d44b21d6e13071f33cd74" resname="ra.menu.ra_profile">
         <source>ra.menu.ra_profile</source>
         <target>Mijn profiel</target>
-        <jms:reference-file line="87">/src/../templates/base.html.twig</jms:reference-file>
+        <jms:reference-file line="92">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d6a9d74b9561d924dc4411c3ceebc63a01c83ae" resname="ra.menu.registration">
         <source>ra.menu.registration</source>
@@ -942,6 +957,11 @@
         <source>ra.menu.search_recovery_tokens</source>
         <target state="needs-l10n">[Recovery tokens]</target>
         <jms:reference-file line="66">/src/../templates/base.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ccf5f7d17e35ed6fd11aad7f781786f7e864d5e5" resname="ra.menu.vetting-type-hint">
+        <source>ra.menu.vetting-type-hint</source>
+        <target state="translated">[Activatie methode hulp]</target>
+        <jms:reference-file line="87">/src/../templates/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5f584865ad00e62914ac47108d14ee076f33c35e" resname="ra.profile.overview.authorizations">
         <source>ra.profile.overview.authorizations</source>
@@ -1449,7 +1469,7 @@
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
         <source>ra.vetting.sms.challenge_body</source>
         <target>Uw SMS-code: %challenge%</target>
-        <jms:reference-file line="242">/src/../src/Surfnet/StepupRa/RaBundle/Service/VettingService.php</jms:reference-file>
+        <jms:reference-file line="247">/src/../src/Surfnet/StepupRa/RaBundle/Service/VettingService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6d55aa46fb97f555148f92291a878be8ed732361" resname="ra.vetting.sms.prove_possession.title.page">
         <source>ra.vetting.sms.prove_possession.title.page</source>
@@ -1542,6 +1562,26 @@ Het token is nu geactiveerd en klaar voor gebruik.</target>
         <source>ra.vetting.yubikey.text.press_once_form_auto_submitted</source>
         <target>Druk op de knop van de Yubikey en houd even vast. Er verschijnt automatisch een eenmalig wachtwoord in het invulveld.</target>
         <jms:reference-file line="17">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/vetting/yubikey/verify.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="aeaa50cfa81a57a14d0bcdb5179bf1fdb528a09e" resname="ra.vetting_type_hint.error">
+        <source>ra.vetting_type_hint.error</source>
+        <target state="translated">Het opslaan van de [activatie methode hulp teksten] is mislukt. Probeer het opnieuw</target>
+        <jms:reference-file line="87">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="503e7024cbbeed07de169176e2e34729e2912693" resname="ra.vetting_type_hint.subtitle">
+        <source>ra.vetting_type_hint.subtitle</source>
+        <target state="translated">[Activatie methode hulpteksten van] %institution%</target>
+        <jms:reference-file line="14">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9e3439b0a5b23046bd4e327b2a802446ab119d3c" resname="ra.vetting_type_hint.success">
+        <source>ra.vetting_type_hint.success</source>
+        <target state="translated">Het opslaan van de [activatie methode hulpteksten] is gelukt</target>
+        <jms:reference-file line="86">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="13411e66cc269e4b4517d14f54a8999680cb5a3e" resname="ra.vetting_type_hint.title">
+        <source>ra.vetting_type_hint.title</source>
+        <target state="new">ra.vetting_type_hint.title</target>
+        <jms:reference-file line="3">/src/../src/Surfnet/StepupRa/RaBundle/Resources/views/vetting_type_hint/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="21ae742a4f478c0afe9accf5d448335bf530a4f9" resname="raa">
         <source>raa</source>

--- a/translations/validators.en_GB.xliff
+++ b/translations/validators.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-13T15:22:45Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2022-07-26T15:44:24Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/translations/validators.nl_NL.xliff
+++ b/translations/validators.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2022-07-13T15:22:42Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2022-07-26T15:44:21Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>


### PR DESCRIPTION
An institution can have a translatable vetting type hint. This hint is displayed at the right place in the self service. A new tab was added to the RA app. Here you can choose an institution. The vetting type hint for that institution is then loaded. No formatting additions where added yet. This however is something to add later on (see [new story](https://www.pivotaltracker.com/story/show/182840207)). Users are allowed to remove a vetting type hint by simply clearing the previous entry in the textarea and saving a blank set of translations.

The available translation options follow the locales configured in the `parameters.yaml`. For now en_GB and nl_NL are configured by default. But adding/removing languages should not be any issue and do not require additional database migrations. As the hints are stored in a JSON blob in the `vetting_type_hints` schema in Middleware.  

See: [PR](https://github.com/OpenConext/Stepup-SelfService/pull/268) for details on the SS changes.
See: https://www.pivotaltracker.com/story/show/182840207

