### PR TITLE
Fix unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {
         "@babel/core": "^7.20.5",
         "@babel/preset-env": "^7.20.2",
-        "@symfony/webpack-encore": "^4",
+        "@symfony/webpack-encore": "^4 <4.5",
         "bootstrap-less": "^3.3.8",
         "core-js": "^3.0.0",
         "font-awesome": "^4.7.0",


### PR DESCRIPTION
Tests started failing since yesterday:

```
yarn install v1.22.19
info No lockfile found.
[1/4] Resolving packages...
warning @symfony/webpack-encore > webpack-dev-server > webpack-dev-middleware > memfs@3.6.0: this will be v4
[2/4] Fetching packages...
error @symfony/webpack-encore@4.5.0: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.21.2"
```

I was able to trace to issue back to a new release of webpack-encore:
https://github.com/symfony/webpack-encore/releases/tag/v4.5.0

This same issue also applies to stepup-selfservice, stepup-gateway, stepup-tiqr and stepup-azure-mfa.
Another approach may be to [raise the Node-version](https://github.com/OpenConext/OpenConext-containers/blob/main/docker/php-test-stepup/Dockerfile#L44), but I wasn't sure how to test/try this.