### PR TITLE
Add input validation for Activation Code and Document Number

### DIFF
--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/StartVettingProcedureType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/StartVettingProcedureType.php
@@ -36,6 +36,7 @@ class StartVettingProcedureType extends AbstractType
                 'autocomplete' => 'off',
                 'placeholder' => 'ra.form.start_vetting_procedure.enter_activation_code_here',
                 'class' => 'fa-search',
+                'pattern' => '[a-z0-9]{8}',
             )
         ]);
         $builder->add('search', SubmitType::class, [

--- a/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
+++ b/src/Surfnet/StepupRa/RaBundle/Form/Type/VerifyIdentityType.php
@@ -35,7 +35,8 @@ class VerifyIdentityType extends AbstractType
                 'autofocus' => true,
                 'autocomplete' => 'off',
                 'maxlength' => 6,
-                'novalidate' => true,
+                'required' => true,
+                'pattern' => '[a-z0-9-]{6}',
             ]
         ]);
         $builder->add('identityVerified', CheckboxType::class, [


### PR DESCRIPTION
This PR:

- Restricts document numbers to 6 characters, being A-Z, 0-9 or a hyphen
- Restricts activation codes to 8 characters, being A-Z or 0-9

Debatable:

- This makes the input of a document number mandatory to be able to send the form. A single `-` is accepted in case a document number isn't of any interest to the RA(A).

Related: https://github.com/OpenConext/Stepup-Middleware/pull/415