### PR TITLE
Replace {} placeholders to %%

### DIFF
--- a/translations/messages+intl-icu.en_GB.xliff
+++ b/translations/messages+intl-icu.en_GB.xliff
@@ -1497,7 +1497,7 @@
       </trans-unit>
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
         <source>ra.vetting.sms.challenge_body</source>
-        <target>Your code: {challenge}</target>
+        <target>Your code: %challenge%</target>
         <jms:reference-file line="247">/src/../src/Surfnet/StepupRa/RaBundle/Service/VettingService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6d55aa46fb97f555148f92291a878be8ed732361" resname="ra.vetting.sms.prove_possession.title.page">

--- a/translations/messages+intl-icu.nl_NL.xliff
+++ b/translations/messages+intl-icu.nl_NL.xliff
@@ -1497,7 +1497,7 @@
       </trans-unit>
       <trans-unit id="8e4a356a46fe95b04ae1cbb201b8d62e15670b2e" resname="ra.vetting.sms.challenge_body">
         <source>ra.vetting.sms.challenge_body</source>
-        <target>Je sms-code: {challenge}</target>
+        <target>Je sms-code: %challenge%</target>
         <jms:reference-file line="247">/src/../src/Surfnet/StepupRa/RaBundle/Service/VettingService.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6d55aa46fb97f555148f92291a878be8ed732361" resname="ra.vetting.sms.prove_possession.title.page">


### PR DESCRIPTION
Because this is not an actual translation, but a string replace in code, we keep the % sign as the placeholder.

This only goes for the challenge variable

### Background:

**ICU Translation Format:**
We've switched to the ICU translation format because it supports pluralization, which is necessary for this project.
The ICU format is similar to the previous format but replaces support for pluralization (e.g., handling "1 token" versus "two tokens").

**Variable Substitution Format Change:**

In the ICU format, variables are expected to be enclosed in {} instead of the Symfony %variable% format used earlier. See https://symfony.com/doc/current/reference/formats/message_format.html

**Specific Variable Handling:**

The %challenge% variable, however, is not utilized within the translation files but is used for variable substitution directly within the code. Therefore, the %challenge% variable's format does not need to be changed to the ICU {} format. The main point is that while translation strings need to adhere to the new ICU format with {}, the specific variable %challenge% used in your code does not require any modification since it is not part of the translation process itself.