### PR TITLE
Manually expire cookies after a configured amount of time

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-use Surfnet\StepupRa\Kernel;
+use src\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 if (!is_file(dirname(__DIR__).'/vendor/autoload.php')) {

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env php
 <?php
 
-use src\Kernel;
+
+use Surfnet\StepupRa\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 if (!is_file(dirname(__DIR__).'/vendor/autoload.php')) {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
             "Surfnet\\": "src\\Surfnet"
         },
         "classmap": [
-            "src/Kernel.php"
+            "src/Surfnet/StepupRa/Kernel.php"
         ]
     },
     "minimum-stability": "stable",

--- a/config/routes/controllers.yaml
+++ b/config/routes/controllers.yaml
@@ -3,5 +3,5 @@ controllers:
     type: attribute
 
 kernel:
-    resource: ../../src/Kernel.php
+    resource: ../../src/Surfnet/StepupRa/Kernel.php
     type: attribute

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -38,3 +38,13 @@ services:
     arguments:
       - '@security.helper'
       - "%logout_redirect_url%"
+
+  Surfnet\StepupRa\RaBundle\EventListener\AuthenticatedUserListener:
+
+  Surfnet\StepupRa\RaBundle\EventListener\ExplicitSessionTimeoutListener:
+
+  Surfnet\StepupRa\RaBundle\Security\Authentication\Session\SessionLifetimeGuard:
+    alias: ra.security.authentication.session.session_lifetime_guard
+
+  Surfnet\StepupRa\RaBundle\Security\Authentication\AuthenticatedSessionStateHandler:
+    alias: ra.security.authentication.session.session_storage

--- a/public/index.php
+++ b/public/index.php
@@ -19,7 +19,7 @@ declare(strict_types = 1);
  */
 
 
-use Surfnet\StepupRa\Kernel;
+use src\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 require_once dirname(__DIR__).'/config/bootstrap.php';

--- a/public/index.php
+++ b/public/index.php
@@ -18,8 +18,7 @@ declare(strict_types = 1);
  * limitations under the License.
  */
 
-
-use src\Kernel;
+use Surfnet\StepupRa\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 require_once dirname(__DIR__).'/config/bootstrap.php';

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
  * limitations under the License.
  */
 
-namespace Surfnet\StepupRa;
+namespace src;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
@@ -30,6 +30,6 @@ class Kernel extends BaseKernel
     // see https://symfony.com/doc/current/reference/configuration/kernel.html#kernel-project-dir
     public function getProjectDir(): string
     {
-        return dirname(__DIR__, 1);
+        return dirname(__DIR__);
     }
 }

--- a/src/Surfnet/StepupRa/Kernel.php
+++ b/src/Surfnet/StepupRa/Kernel.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
  * limitations under the License.
  */
 
-namespace src;
+namespace Surfnet\StepupRa;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
@@ -30,6 +30,6 @@ class Kernel extends BaseKernel
     // see https://symfony.com/doc/current/reference/configuration/kernel.html#kernel-project-dir
     public function getProjectDir(): string
     {
-        return dirname(__DIR__);
+        return dirname(__DIR__, 3);
     }
 }

--- a/src/Surfnet/StepupRa/RaBundle/EventListener/AuthenticatedUserListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/AuthenticatedUserListener.php
@@ -3,7 +3,7 @@
 declare(strict_types = 1);
 
 /**
- * Copyright 2016 SURFnet bv
+ * Copyright 2024 SURFnet bv
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,6 @@ class AuthenticatedUserListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            // The firewall, which makes the token available, listens at P8
-            // We must jump in after the firewall, forcing us to overwrite the translator locale.
             KernelEvents::REQUEST => ['updateLastInteractionMoment', 6],
         ];
     }

--- a/src/Surfnet/StepupRa/RaBundle/EventListener/AuthenticatedUserListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/AuthenticatedUserListener.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2016 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+
+use Surfnet\StepupRa\RaBundle\Security\Authentication\AuthenticatedSessionStateHandler;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Session\SessionLifetimeGuard;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class AuthenticatedUserListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly TokenStorageInterface            $tokenStorage,
+        private readonly SessionLifetimeGuard             $sessionLifetimeGuard,
+        private readonly AuthenticatedSessionStateHandler $sessionStateHandler,
+        private readonly LoggerInterface                  $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // The firewall, which makes the token available, listens at P8
+            // We must jump in after the firewall, forcing us to overwrite the translator locale.
+            KernelEvents::REQUEST => ['updateLastInteractionMoment', 6],
+        ];
+    }
+
+    public function updateLastInteractionMoment(RequestEvent $event): void
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if ($token === null || !$this->sessionLifetimeGuard->sessionLifetimeWithinLimits($this->sessionStateHandler)) {
+            return;
+        }
+        $this->logger->notice('Logged in user with a session within time limits detected, updating session state');
+
+        // see ExplicitSessionTimeoutHandler for the rationale
+        if ($event->getRequest()->getMethod() === 'GET') {
+            $this->sessionStateHandler->setCurrentRequestUri($event->getRequest()->getRequestUri());
+        }
+        $this->sessionStateHandler->updateLastInteractionMoment();
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/EventListener/ExplicitSessionTimeoutListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/ExplicitSessionTimeoutListener.php
@@ -49,8 +49,6 @@ final readonly class ExplicitSessionTimeoutListener implements EventSubscriberIn
     public static function getSubscribedEvents(): array
     {
         return [
-            // The firewall, which makes the token available, listens at P8
-            // We must jump in after the firewall, forcing us to overwrite the translator locale.
             KernelEvents::REQUEST => ['checkSessionTimeout', 5],
         ];
     }

--- a/src/Surfnet/StepupRa/RaBundle/EventListener/ExplicitSessionTimeoutListener.php
+++ b/src/Surfnet/StepupRa/RaBundle/EventListener/ExplicitSessionTimeoutListener.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupRa\RaBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\AuthenticatedSessionStateHandler;
+use Surfnet\StepupRa\RaBundle\Security\Authentication\Session\SessionLifetimeGuard;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final readonly class ExplicitSessionTimeoutListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private TokenStorageInterface            $tokenStorage,
+        private AuthenticatedSessionStateHandler $authenticatedSession,
+        #[Autowire(service: 'ra.security.authentication.session.session_lifetime_guard')]
+        private SessionLifetimeGuard             $sessionLifetimeGuard,
+        private RouterInterface                  $router,
+        private LoggerInterface                  $logger,
+        private EventDispatcherInterface         $eventDispatcher,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // The firewall, which makes the token available, listens at P8
+            // We must jump in after the firewall, forcing us to overwrite the translator locale.
+            KernelEvents::REQUEST => ['checkSessionTimeout', 5],
+        ];
+    }
+
+    public function checkSessionTimeout(RequestEvent $event): void
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if ($token === null || $this->sessionLifetimeGuard->sessionLifetimeWithinLimits($this->authenticatedSession)) {
+            return;
+        }
+
+        $invalidatedBy = [];
+        if (!$this->sessionLifetimeGuard->sessionLifetimeWithinAbsoluteLimit($this->authenticatedSession)) {
+            $invalidatedBy[] = 'absolute';
+        }
+
+        if (!$this->sessionLifetimeGuard->sessionLifetimeWithinRelativeLimit($this->authenticatedSession)) {
+            $invalidatedBy[] = 'relative';
+        }
+
+        $this->logger->notice(sprintf(
+            'Authenticated user found, but session was determined to be outside of the "%s" time limit. User will '
+            . 'be logged out and redirected to session-expired page to attempt new login.',
+            implode(' and ', $invalidatedBy),
+        ));
+
+        $request = $event->getRequest();
+
+        // if the current request was not a GET request we cannot safely redirect to that page after login as it
+        // may require a form resubmit for instance. Therefor, we redirect to the last GET request (either current
+        // or previous).
+        $afterLoginRedirectTo = $this->authenticatedSession->getCurrentRequestUri();
+
+        if ($event->getRequest()->getMethod() === 'GET') {
+            $afterLoginRedirectTo = $event->getRequest()->getRequestUri();
+        }
+
+        // log the user out using Symfony methodology, see the LogoutListener
+        $event->setResponse(new RedirectResponse($this->router->generate('selfservice_security_session_expired')));
+
+        // something to clear cookies
+        $this->eventDispatcher->dispatch(new LogoutEvent($request, $token));
+        $this->tokenStorage->setToken(null);
+
+        // the session is restarted after invalidation during the logout, so we can (re)store the last GET request
+        $this->authenticatedSession->setCurrentRequestUri($afterLoginRedirectTo);
+    }
+}

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Session/SessionLifetimeGuardTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Session/SessionLifetimeGuardTest.php
@@ -239,7 +239,7 @@ class SessionLifetimeGuardTest extends TestCase
     {
         $nowProperty = new ReflectionProperty(DateTime::class, 'now');
         $nowProperty->setAccessible(true);
-        $nowProperty->setValue($now);
+        $nowProperty->setValue(null, $now);
     }
 
     /**

--- a/src/Surfnet/StepupRa/RaBundle/Tests/Security/Session/SessionStorageTest.php
+++ b/src/Surfnet/StepupRa/RaBundle/Tests/Security/Session/SessionStorageTest.php
@@ -343,6 +343,6 @@ class SessionStorageTest extends TestCase
     {
         $nowProperty = new ReflectionProperty(DateTime::class, 'now');
         $nowProperty->setAccessible(true);
-        $nowProperty->setValue($now);
+        $nowProperty->setValue(null, $now);
     }
 }


### PR DESCRIPTION
Add listeners to replace the "old" handlers to manage cookie expiration. The values in     `session_max_absolute_lifetime:` and `session_max_relative_lifetime:` will be used to calculate expiration