### PR TITLE
Fix remote metadata endpoint

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -54,3 +54,7 @@ services:
     public: false
     arguments:
       $exceptionController: '@Surfnet\StepupRa\RaBundle\Controller\ExceptionController'
+
+  Surfnet\StepupRa\RaBundle\Controller\SamlController:
+    bind:
+      $remoteIdp: '@surfnet_saml.remote.idp'


### PR DESCRIPTION
Bind the remote IdP setting so it can be used in the metadata endpoint.

https://github.com/OpenConext/Stepup-RA/issues/342